### PR TITLE
Update Dart SDK lower bound to 3.2

### DIFF
--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_generative_ai
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   crypt: ^4.3.0

--- a/samples/pubspec.yaml
+++ b/samples/pubspec.yaml
@@ -2,7 +2,7 @@ name: generative_ai_samples
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   path: ^1.9.0


### PR DESCRIPTION
The 3.2.0 SDK narrowed the return type of `utf8.encode` to `Uint8List`
from `List<int>`. This implementation depends on inferring `Uint8List`
for the variable type.
