### PR TITLE
Allow overriding a baseUri on GenerativeModel

### DIFF
--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -259,6 +259,8 @@ GenerativeModel createModelWithClient(
 /// backend.
 ///
 /// Used from a `src/` import in the Vertex AI SDK.
+// TODO: https://github.com/google/generative-ai-dart/issues/111 - Changes to
+// this API need to be coordinated with the vertex AI SDK.
 GenerativeModel createModelWithBaseUri(
         {required String model,
         required String apiKey,


### PR DESCRIPTION
Allow the Vertex AI SDK to be implemented on top of `GenerativeModel`
without exposing any change to end users. Add a side method to create a
`GenerativeModel` with a specific base URI. The model code and task will
be appended.

- Add a `createModelWithBaseUri` top level method which is not exported
  outside of the `src/` library.
- Rename `_baseUrl` to `_googleAiBaseUri` to disambiguate against the
  `_baseUri` field. Use "uri" over "url" more consistently.