### PR TITLE
Switch to API version v1beta

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2-wip
+
+- Use API version `v1beta` by default.
+
 ## 0.3.1
 
 - Add support on content generating methods for overriding "tools" passed when

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -21,7 +21,7 @@ import 'client.dart';
 import 'content.dart';
 import 'function_calling.dart';
 
-const _apiVersion = 'v1';
+const _apiVersion = 'v1beta';
 Uri _googleAIBaseUri(RequestOptions? options) => Uri.https(
     'generativelanguage.googleapis.com', options?.apiVersion ?? _apiVersion);
 
@@ -40,8 +40,7 @@ enum Task {
 final class RequestOptions {
   /// The API version used to make requests.
   ///
-  /// By default the version is `v1`. This may be specified as `v1beta` to use
-  /// beta features.
+  /// By default the version is `v1beta`.
   final String? apiVersion;
   const RequestOptions({this.apiVersion});
 }
@@ -86,15 +85,12 @@ final class GenerativeModel {
   /// request.
   ///
   /// Functions that the model may call while generating content can be passed
-  /// in [tools]. When using tools [requestOptions] must be passed to
-  /// override the `apiVersion` to `v1beta`. Tool usage by the model can be
-  /// configured with [toolConfig]. Tools and tool configuration can be
-  /// overridden for individual requests with arguments to [generateContent] or
-  /// [generateContentStream].
+  /// in [tools]. Tool usage by the model can be configured with [toolConfig].
+  /// Tools and tool configuration can be overridden for individual requests
+  /// with arguments to [generateContent] or [generateContentStream].
   ///
   /// A [Content.system] can be passed to [systemInstruction] to give
-  /// high priority instructions to the model. When using system instructions
-  /// [requestOptions] must be passed to override the `apiVersion` to `v1beta`.
+  /// high priority instructions to the model.
   factory GenerativeModel({
     required String model,
     required String apiKey,

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.1';
+const packageVersion = '0.3.2-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.1
+version: 0.3.2-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/chat_test.dart
+++ b/pkgs/google_generative_ai/test/chat_test.dart
@@ -39,7 +39,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'models/some-model:generateContent'),
         {
           'contents': [
@@ -95,7 +95,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'models/some-model:generateContent'),
         {
           'contents': [
@@ -143,7 +143,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stubStream(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'models/some-model:streamGenerateContent'),
         {
           'contents': [
@@ -196,7 +196,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'models/some-model:generateContent'),
         {
           'contents': [

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -48,7 +48,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'models/some-model:generateContent'),
         {
           'contents': [
@@ -88,7 +88,7 @@ void main() {
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
             'tunedModels/some-model:generateContent'),
         {
           'contents': [
@@ -168,7 +168,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -207,7 +207,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -256,7 +256,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -301,7 +301,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -358,7 +358,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -417,7 +417,7 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:generateContent'),
           {
             'contents': [
@@ -490,7 +490,7 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:streamGenerateContent'),
           {
             'contents': [
@@ -535,7 +535,7 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:streamGenerateContent'),
           {
             'contents': [
@@ -590,7 +590,7 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:streamGenerateContent'),
           {
             'contents': [
@@ -640,7 +640,7 @@ void main() {
         final (client, model) = createModel();
         final prompt = 'Some prompt';
         client.stub(
-            Uri.parse('https://generativelanguage.googleapis.com/v1/'
+            Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
                 'models/some-model:countTokens'),
             {
               'contents': [
@@ -665,7 +665,7 @@ void main() {
         final (client, model) = createModel();
         final prompt = 'Some prompt';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:embedContent'),
           {
             'content': {
@@ -697,7 +697,7 @@ void main() {
         final embedding1 = [0.1, 0.2, 0.3];
         final embedding2 = [0.4, 0.5, 1.6];
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
               'models/some-model:batchEmbedContents'),
           {
             'requests': [

--- a/samples/dart/bin/function_calling.dart
+++ b/samples/dart/bin/function_calling.dart
@@ -23,23 +23,23 @@ void main() async {
     exit(1);
   }
   final model = GenerativeModel(
-      model: 'gemini-pro',
-      apiKey: apiKey,
-      tools: [
-        Tool(functionDeclarations: [
-          FunctionDeclaration(
-              'fetchCurrentWeather',
-              'Returns the weather in a given location.',
-              Schema(SchemaType.object, properties: {
-                'location': Schema(SchemaType.string),
-                'unit': Schema(SchemaType.string,
-                    enumValues: ['celcius', 'farenheit'])
-              }, requiredProperties: [
-                'location'
-              ]))
-        ])
-      ],
-      requestOptions: RequestOptions(apiVersion: 'v1beta'));
+    model: 'gemini-pro',
+    apiKey: apiKey,
+    tools: [
+      Tool(functionDeclarations: [
+        FunctionDeclaration(
+            'fetchCurrentWeather',
+            'Returns the weather in a given location.',
+            Schema(SchemaType.object, properties: {
+              'location': Schema(SchemaType.string),
+              'unit': Schema(SchemaType.string,
+                  enumValues: ['celcius', 'farenheit'])
+            }, requiredProperties: [
+              'location'
+            ]))
+      ])
+    ],
+  );
 
   final prompt = 'What is the weather in Seattle?';
   final content = [Content.text(prompt)];


### PR DESCRIPTION
For consistency across the client and server focused SDKs, and because
the SDK entirely is in preview, switch to the beta API version by
default.
