### PR TITLE
Add caution note to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 The Google Generative AI SDK for Dart allows developers to use state-of-the-art
 Large Language Models (LLMs) to build language applications.
 
+> [!CAUTION]
+> **Using the Google AI SDK for Dart (Flutter) to call the Google AI Gemini API
+> directly from your app is recommended for prototyping only.** If you plan to
+> enable billing, we strongly recommend that you use the SDK to call the Google
+> AI Gemini API only server-side to keep your API key safe. You risk potentially
+> exposing your API key to malicious actors if you embed your API key directly
+> in your mobile or web app or fetch it remotely at runtime.
+
 ## Getting Started
 
 ### API keys

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.3.2-wip
+## 0.3.2
 
 - Use API version `v1beta` by default.
+- Add note to README warning about leaking API keys.
 
 ## 0.3.1
 

--- a/pkgs/google_generative_ai/README.md
+++ b/pkgs/google_generative_ai/README.md
@@ -11,6 +11,14 @@ applications. This SDK supports use cases like:
 -   Build multi-turn conversations (chat)
 -   Embedding
 
+> [!CAUTION]
+> **Using the Google AI SDK for Dart (Flutter) to call the Google AI Gemini API
+> directly from your app is recommended for prototyping only.** If you plan to
+> enable billing, we strongly recommend that you use the SDK to call the Google
+> AI Gemini API only server-side to keep your API key safe. You risk potentially
+> exposing your API key to malicious actors if you embed your API key directly
+> in your mobile or web app or fetch it remotely at runtime.
+
 ## Getting started
 
 ### Get an API key

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.2-wip';
+const packageVersion = '0.3.2';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.2-wip
+version: 0.3.2
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
Add a note warning against leaking API keys with billing enabled in
client side applications.
Add to both the top-level README for this repository, as well as the
README published with the package and rendered on the pub site.

Drop `-wip` suffix from version to prepare for publish.
