### PR TITLE
Add link to API version doc

### DIFF
--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -41,6 +41,7 @@ final class RequestOptions {
   /// The API version used to make requests.
   ///
   /// By default the version is `v1beta`.
+  /// See https://ai.google.dev/gemini-api/docs/api-versions for details.
   final String? apiVersion;
   const RequestOptions({this.apiVersion});
 }


### PR DESCRIPTION
It's unlikely we will want to maintain copied information  about version
compatibility with the official docs, so link to them instead.
