### PR TITLE
Add usageMetadata to GenerateContentResponse

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.3.3-wip
+## 0.3.3
+
+- Add support for parsing the `usageMetadata` field in `GenerateContentResponse`
+  messages.
 
 ## 0.3.2
 

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.3-wip';
+const packageVersion = '0.3.3';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.3-wip
+version: 0.3.3
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/samples/dart/bin/advanced_text.dart
+++ b/samples/dart/bin/advanced_text.dart
@@ -36,6 +36,11 @@ void main() async {
 
   final responses = model.generateContentStream(content);
   await for (final response in responses) {
+    if (response.usageMetadata case final usageMetadata?) {
+      stdout.writeln('(Usage: prompt - ${usageMetadata.promptTokenCount}), '
+          'candidates - ${usageMetadata.candidatesTokenCount}, '
+          'total - ${usageMetadata.totalTokenCount}');
+    }
     stdout.write(response.text);
   }
   stdout.writeln();


### PR DESCRIPTION
Add `UsageMetadata` and relevante parsing. Add a `usageMetadata` field
on `GenerateContentResponse`.

Add usage of the new field to the advanced text sample.

Refactor the `GenerateContentResponse` parse method to handled each
field individually at the top level. There is a behavior change for an
error case, but it is not visible through the message formats that are
returned from the backend in practice.

Prepare to publish.
