### PR TITLE
Add support for reduced output dimensionality in embeddings

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Add named constructors on `Schema` for each value type.
 - Add `GenerationConfig.responseMimeType` which supports setting
   `'application/json'` to force the model to reply with JSON parseable output.
+- Add `outputDimensionality` argument support for `embedContent` and
+  `batchEmbedContent`.
 
 ## 0.3.3
 

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -117,13 +117,18 @@ final class EmbedContentRequest {
   final TaskType? taskType;
   final String? title;
   final String? model;
-  EmbedContentRequest(this.content, {this.taskType, this.title, this.model});
+  final int? outputDimensionality;
+
+  EmbedContentRequest(this.content,
+      {this.taskType, this.title, this.model, this.outputDimensionality});
 
   Object toJson({String? defaultModel}) => {
         'content': content.toJson(),
         if (taskType case final taskType?) 'taskType': taskType.toJson(),
         if (title != null) 'title': title,
         if (model ?? defaultModel case final model?) 'model': model,
+        if (outputDimensionality != null)
+          'outputDimensionality': outputDimensionality,
       };
 }
 

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -269,11 +269,13 @@ final class GenerativeModel {
   ///     (await model.embedContent([Content.text(prompt)])).embedding.values;
   /// ```
   Future<EmbedContentResponse> embedContent(Content content,
-      {TaskType? taskType, String? title}) async {
+      {TaskType? taskType, String? title, int? outputDimensionality}) async {
     final parameters = <String, Object?>{
       'content': content.toJson(),
       if (taskType != null) 'taskType': taskType.toJson(),
-      if (title != null) 'title': title
+      if (title != null) 'title': title,
+      if (outputDimensionality != null)
+        'outputDimensionality': outputDimensionality,
     };
     final response =
         await _client.makeRequest(_taskUri(Task.embedContent), parameters);

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -689,6 +689,38 @@ void main() {
       });
     });
 
+    test('embed content with reduced output dimensionality', () async {
+      final (client, model) = createModel();
+      final content = 'Some content';
+      final outputDimensionality = 1;
+      final embeddingValues = [0.1];
+
+      client.stub(
+        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:embedContent'),
+        {
+          'content': {
+            'role': 'user',
+            'parts': [
+              {'text': content}
+            ]
+          },
+          'outputDimensionality': outputDimensionality,
+        },
+        {
+          'embedding': {'values': embeddingValues}
+        },
+      );
+
+      final response = await model.embedContent(Content.text(content),
+          outputDimensionality: outputDimensionality);
+
+      expect(
+          response,
+          matchesEmbedContentResponse(
+              EmbedContentResponse(ContentEmbedding(embeddingValues))));
+    });
+
     group('batch embed contents', () {
       test('can make successful request', () async {
         final (client, model) = createModel();
@@ -736,6 +768,64 @@ void main() {
             response,
             matchesBatchEmbedContentsResponse(BatchEmbedContentsResponse(
                 [ContentEmbedding(embedding1), ContentEmbedding(embedding2)])));
+      });
+
+      test('batch embed contents with reduced output dimensionality', () async {
+        final (client, model) = createModel();
+        final content1 = 'Some content 1';
+        final content2 = 'Some content 2';
+        final outputDimensionality = 1;
+        final embeddingValues1 = [0.1];
+        final embeddingValues2 = [0.4];
+
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
+              'models/some-model:batchEmbedContents'),
+          {
+            'requests': [
+              {
+                'content': {
+                  'role': 'user',
+                  'parts': [
+                    {'text': content1}
+                  ]
+                },
+                'model': 'models/$defaultModelName',
+                'outputDimensionality': outputDimensionality,
+              },
+              {
+                'content': {
+                  'role': 'user',
+                  'parts': [
+                    {'text': content2}
+                  ]
+                },
+                'model': 'models/$defaultModelName',
+                'outputDimensionality': outputDimensionality,
+              },
+            ],
+          },
+          {
+            'embeddings': [
+              {'values': embeddingValues1},
+              {'values': embeddingValues2},
+            ],
+          },
+        );
+
+        final response = await model.batchEmbedContents([
+          EmbedContentRequest(Content.text(content1),
+              outputDimensionality: outputDimensionality),
+          EmbedContentRequest(Content.text(content2),
+              outputDimensionality: outputDimensionality),
+        ]);
+
+        expect(
+            response,
+            matchesBatchEmbedContentsResponse(BatchEmbedContentsResponse([
+              ContentEmbedding(embeddingValues1),
+              ContentEmbedding(embeddingValues2),
+            ])));
       });
     });
   });


### PR DESCRIPTION
This PR adds support for reducing the output dimensionality of the generated embeddings.

Related docs: 
- https://ai.google.dev/api/rest/v1beta/models/embedContent
- https://ai.google.dev/api/rest/v1beta/models/batchEmbedContents