### PR TITLE
Add note about unused harm categories

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.4-wip
+
 ## 0.3.3
 
 - Add support for parsing the `usageMetadata` field in `GenerateContentResponse`

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -246,6 +246,9 @@ enum BlockReason {
 ///
 /// These categories cover various kinds of harms that developers may wish to
 /// adjust.
+///
+/// Some categories from the rest API are excluded because they are not used by
+/// the Gemini generative models.
 enum HarmCategory {
   unspecified,
 

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.3';
+const packageVersion = '0.3.4-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.3
+version: 0.3.4-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
The rest API discovery document lists harm categories that will never be
returned in practice because they were created for earlier models. Add a
not about this to the doc comment to prevent confusion about missing
values. See #150.
