### PR TITLE
Add named constructors for Schema types

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.3.4-wip
 
+- Add named constructors on `Schema` for each value type.
+
 ## 0.3.3
 
 - Add support for parsing the `usageMetadata` field in `GenerateContentResponse`

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -177,6 +177,7 @@ final class Schema {
     this.requiredProperties,
   });
 
+  /// Construct a schema for a String value.
   Schema.string({
     String? description,
     bool? nullable,
@@ -185,6 +186,8 @@ final class Schema {
           description: description,
           nullable: nullable,
         );
+
+  /// Construct a schema for String value with enumerated possible values.
   Schema.enumString({
     required List<String> enumValues,
     String? description,
@@ -222,6 +225,8 @@ final class Schema {
           description: description,
           nullable: nullable,
         );
+
+  /// Construct a schema for bool value.
   Schema.boolean({
     String? description,
     bool? nullable,
@@ -230,6 +235,8 @@ final class Schema {
           description: description,
           nullable: nullable,
         );
+
+  /// Construct a schema for an array of values with a specified type.
   Schema.array({
     required Schema items,
     String? description,
@@ -240,6 +247,8 @@ final class Schema {
           nullable: nullable,
           items: items,
         );
+
+  /// Construct a schema for an object with one or more properties.
   Schema.object({
     required Map<String, Schema> properties,
     List<String>? requiredProperties,

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -177,6 +177,82 @@ final class Schema {
     this.requiredProperties,
   });
 
+  Schema.string({
+    String? description,
+    bool? nullable,
+  }) : this(
+          SchemaType.string,
+          description: description,
+          nullable: nullable,
+        );
+  Schema.enumString({
+    required List<String> enumValues,
+    String? description,
+    bool? nullable,
+  }) : this(
+          SchemaType.string,
+          enumValues: enumValues,
+          description: description,
+          nullable: nullable,
+          format: 'enum',
+        );
+
+  /// Construct a schema for a non-integer number.
+  ///
+  /// The [format] may be "float" or "double".
+  Schema.number({
+    String? description,
+    bool? nullable,
+    String? format,
+  }) : this(
+          SchemaType.number,
+          description: description,
+          nullable: nullable,
+        );
+
+  /// Construct a schema for an integer number.
+  ///
+  /// The [format] may be "int32" or "int64".
+  Schema.integer({
+    String? description,
+    bool? nullable,
+    String? format,
+  }) : this(
+          SchemaType.integer,
+          description: description,
+          nullable: nullable,
+        );
+  Schema.boolean({
+    String? description,
+    bool? nullable,
+  }) : this(
+          SchemaType.boolean,
+          description: description,
+          nullable: nullable,
+        );
+  Schema.array({
+    required Schema items,
+    String? description,
+    bool? nullable,
+  }) : this(
+          SchemaType.array,
+          description: description,
+          nullable: nullable,
+          items: items,
+        );
+  Schema.object({
+    required Map<String, Schema> properties,
+    List<String>? requiredProperties,
+    String? description,
+    bool? nullable,
+  }) : this(
+          SchemaType.object,
+          properties: properties,
+          requiredProperties: requiredProperties,
+          description: description,
+          nullable: nullable,
+        );
+
   Map<String, Object> toJson() => {
         'type': type.toJson(),
         if (format case final format?) 'format': format,


### PR DESCRIPTION
Closes #130

Adds named constructors for each `SchemaType` enum value.
- Saves a few characters at the call site (no need to repeat the noisy
  `SchemaType.` name).
- Restricts the arguments to those which are sensible for each type.
