### PR TITLE
Mark some flutter files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+samples/*/.metadata linguist-generated=true
+samples/**/Flutter/GeneratedPluginRegistrant.swift linguist-generated=true
+samples/**/Runner.xcodeproj/ linguist-generated=true
+samples/**/Runner.xcworkspace/ linguist-generated=true
+samples/**/flutter/CMakeLists.txt linguist-generated=true
+samples/**/flutter/generated_* linguist-generated=true


### PR DESCRIPTION
Add a `.gitattributes` file with some patterns for files created by the
flutter templates.

This list is the patterns that look the least likely to be manually
edited, although there are many other files with generated (and
unedited) boilerplate that look like it _might_ change in a manual
commit at some point which will still add noise in new app PRs.
- `.metada`, `flutter/CMakeLists.txtx`,
  `GenerateDPluginRegistrant.swift`, and the `generated_*` pattern files
  have comments indicating they are generated and should not be edited.
- The `Runner.xcodeproj` and `Runner.xcworkspace` directories contain
  xml files and look very unlikely to be hand-edited.
