### PR TITLE
Insert formatting trailing commas in tests

### DIFF
--- a/pkgs/google_generative_ai/test/chat_test.dart
+++ b/pkgs/google_generative_ai/test/chat_test.dart
@@ -23,8 +23,9 @@ void main() {
   group('Chat', () {
     const defaultModelName = 'some-model';
 
-    (StubClient, GenerativeModel) createModel(
-        [String modelName = defaultModelName]) {
+    (StubClient, GenerativeModel) createModel([
+      String modelName = defaultModelName,
+    ]) {
       final client = StubClient();
       final model = createModelWithClient(model: modelName, client: client);
       return (client, model);
@@ -34,34 +35,36 @@ void main() {
       final (client, model) = createModel('models/$defaultModelName');
       final chat = model.startChat(history: [
         Content.text('Hi!'),
-        Content.model([TextPart('Hello, how can I help you today?')])
+        Content.model([TextPart('Hello, how can I help you today?')]),
       ]);
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': 'Hi!'}
-              ]
+                {'text': 'Hi!'},
+              ],
             },
             {
               'role': 'model',
               'parts': [
-                {'text': 'Hello, how can I help you today?'}
-              ]
+                {'text': 'Hello, how can I help you today?'},
+              ],
             },
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
+                {'text': prompt},
+              ],
             },
-          ]
+          ],
         },
         {
           'candidates': [
@@ -69,48 +72,60 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await chat.sendMessage(Content.text(prompt));
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
       expect(
-          chat.history.last, matchesContent(response.candidates.first.content));
+        chat.history.last,
+        matchesContent(response.candidates.first.content),
+      );
     });
 
     test('forwards safety settings', () async {
       final (client, model) = createModel('models/$defaultModelName');
       final chat = model.startChat(safetySettings: [
-        SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
+        SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high),
       ]);
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
+                {'text': prompt},
+              ],
             },
           ],
           'safetySettings': [
             {
               'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
-              'threshold': 'BLOCK_ONLY_HIGH'
-            }
+              'threshold': 'BLOCK_ONLY_HIGH',
+            },
           ],
         },
         {
@@ -119,49 +134,59 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await chat.sendMessage(Content.text(prompt));
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
     });
 
     test('forwards safety settings and config when streaming', () async {
       final (client, model) = createModel('models/$defaultModelName');
       final chat = model.startChat(safetySettings: [
-        SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
+        SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high),
       ], generationConfig: GenerationConfig(stopSequences: ['a']));
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stubStream(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:streamGenerateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:streamGenerateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
+                {'text': prompt},
+              ],
             },
           ],
           'safetySettings': [
             {
               'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
-              'threshold': 'BLOCK_ONLY_HIGH'
-            }
+              'threshold': 'BLOCK_ONLY_HIGH',
+            },
           ],
           'generationConfig': {
-            'stopSequences': ['a']
+            'stopSequences': ['a'],
           },
         },
         [
@@ -171,44 +196,54 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
-          }
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
+          },
         ],
       );
       final responses =
           await chat.sendMessageStream(Content.text(prompt)).toList();
       expect(responses, [
-        matchesGenerateContentResponse(GenerateContentResponse([
-          Candidate(
-              Content('model', [TextPart(result)]), null, null, null, null),
-        ], null))
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
+            Candidate(
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
       ]);
     });
 
     test('forwards generation config', () async {
       final (client, model) = createModel('models/$defaultModelName');
       final chat = model.startChat(
-          generationConfig: GenerationConfig(stopSequences: ['a']));
+        generationConfig: GenerationConfig(stopSequences: ['a']),
+      );
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
+                {'text': prompt},
+              ],
             },
           ],
           'generationConfig': {
-            'stopSequences': ['a']
+            'stopSequences': ['a'],
           },
         },
         {
@@ -217,20 +252,28 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await chat.sendMessage(Content.text(prompt));
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
     });
   });
 }

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -844,29 +844,35 @@ void main() {
       final embeddingValues = [0.1];
 
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:embedContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:embedContent',
+        ),
         {
           'content': {
             'role': 'user',
             'parts': [
-              {'text': content}
-            ]
+              {'text': content},
+            ],
           },
           'outputDimensionality': outputDimensionality,
         },
         {
-          'embedding': {'values': embeddingValues}
+          'embedding': {'values': embeddingValues},
         },
       );
 
-      final response = await model.embedContent(Content.text(content),
-          outputDimensionality: outputDimensionality);
+      final response = await model.embedContent(
+        Content.text(content),
+        outputDimensionality: outputDimensionality,
+      );
 
       expect(
-          response,
-          matchesEmbedContentResponse(
-              EmbedContentResponse(ContentEmbedding(embeddingValues))));
+        response,
+        matchesEmbedContentResponse(
+          EmbedContentResponse(ContentEmbedding(embeddingValues)),
+        ),
+      );
     });
 
     group('batch embed contents', () {
@@ -934,16 +940,18 @@ void main() {
         final embeddingValues2 = [0.4];
 
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:batchEmbedContents'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:batchEmbedContents',
+          ),
           {
             'requests': [
               {
                 'content': {
                   'role': 'user',
                   'parts': [
-                    {'text': content1}
-                  ]
+                    {'text': content1},
+                  ],
                 },
                 'model': 'models/$defaultModelName',
                 'outputDimensionality': outputDimensionality,
@@ -952,8 +960,8 @@ void main() {
                 'content': {
                   'role': 'user',
                   'parts': [
-                    {'text': content2}
-                  ]
+                    {'text': content2},
+                  ],
                 },
                 'model': 'models/$defaultModelName',
                 'outputDimensionality': outputDimensionality,
@@ -969,18 +977,25 @@ void main() {
         );
 
         final response = await model.batchEmbedContents([
-          EmbedContentRequest(Content.text(content1),
-              outputDimensionality: outputDimensionality),
-          EmbedContentRequest(Content.text(content2),
-              outputDimensionality: outputDimensionality),
+          EmbedContentRequest(
+            Content.text(content1),
+            outputDimensionality: outputDimensionality,
+          ),
+          EmbedContentRequest(
+            Content.text(content2),
+            outputDimensionality: outputDimensionality,
+          ),
         ]);
 
         expect(
-            response,
-            matchesBatchEmbedContentsResponse(BatchEmbedContentsResponse([
+          response,
+          matchesBatchEmbedContentsResponse(
+            BatchEmbedContentsResponse([
               ContentEmbedding(embeddingValues1),
               ContentEmbedding(embeddingValues2),
-            ])));
+            ]),
+          ),
+        );
       });
     });
   });

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -43,22 +43,25 @@ void main() {
     }
 
     test('strips leading "models/" from model name', () async {
-      final (client, model) =
-          createModel(modelName: 'models/$defaultModelName');
+      final (client, model) = createModel(
+        modelName: 'models/$defaultModelName',
+      );
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'models/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'models/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
-            }
-          ]
+                {'text': prompt},
+              ],
+            },
+          ],
         },
         {
           'candidates': [
@@ -66,39 +69,50 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await model.generateContent([Content.text(prompt)]);
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
     });
 
     test('allows specifying a tuned model', () async {
-      final (client, model) =
-          createModel(modelName: 'tunedModels/$defaultModelName');
+      final (client, model) = createModel(
+        modelName: 'tunedModels/$defaultModelName',
+      );
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-            'tunedModels/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/v1beta/'
+          'tunedModels/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
-            }
-          ]
+                {'text': prompt},
+              ],
+            },
+          ],
         },
         {
           'candidates': [
@@ -106,39 +120,50 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await model.generateContent([Content.text(prompt)]);
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
     });
 
     test('allows specifying an API version', () async {
       final (client, model) = createModel(
-          requestOptions: RequestOptions(apiVersion: 'override_version'));
+        requestOptions: RequestOptions(apiVersion: 'override_version'),
+      );
       final prompt = 'Some prompt';
       final result = 'Some response';
       client.stub(
-        Uri.parse('https://generativelanguage.googleapis.com/override_version/'
-            'models/some-model:generateContent'),
+        Uri.parse(
+          'https://generativelanguage.googleapis.com/override_version/'
+          'models/some-model:generateContent',
+        ),
         {
           'contents': [
             {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
-            }
-          ]
+                {'text': prompt},
+              ],
+            },
+          ],
         },
         {
           'candidates': [
@@ -146,20 +171,28 @@ void main() {
               'content': {
                 'role': 'model',
                 'parts': [
-                  {'text': result}
-                ]
-              }
-            }
-          ]
+                  {'text': result},
+                ],
+              },
+            },
+          ],
         },
       );
       final response = await model.generateContent([Content.text(prompt)]);
       expect(
-          response,
-          matchesGenerateContentResponse(GenerateContentResponse([
+        response,
+        matchesGenerateContentResponse(
+          GenerateContentResponse([
             Candidate(
-                Content('model', [TextPart(result)]), null, null, null, null),
-          ], null)));
+              Content('model', [TextPart(result)]),
+              null,
+              null,
+              null,
+              null,
+            ),
+          ], null),
+        ),
+      );
     });
 
     group('generate unary content', () {
@@ -168,17 +201,19 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
-            ]
+                  {'text': prompt},
+                ],
+              },
+            ],
           },
           {
             'candidates': [
@@ -186,20 +221,28 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
         final response = await model.generateContent([Content.text(prompt)]);
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
 
       test('can override safety settings', () async {
@@ -207,22 +250,24 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'safetySettings': [
               {
                 'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
-                'threshold': 'BLOCK_ONLY_HIGH'
-              }
+                'threshold': 'BLOCK_ONLY_HIGH',
+              },
             ],
           },
           {
@@ -231,24 +276,36 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
-        final response = await model.generateContent([
-          Content.text(prompt)
-        ], safetySettings: [
-          SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
-        ]);
+        final response = await model.generateContent(
+          [Content.text(prompt)],
+          safetySettings: [
+            SafetySetting(
+              HarmCategory.dangerousContent,
+              HarmBlockThreshold.high,
+            ),
+          ],
+        );
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
 
       test('can override generation config', () async {
@@ -256,19 +313,21 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'generationConfig': {
-              'stopSequences': ['a']
+              'stopSequences': ['a'],
             },
           },
           {
@@ -277,45 +336,57 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
-        final response = await model.generateContent([Content.text(prompt)],
-            generationConfig: GenerationConfig(stopSequences: ['a']));
+        final response = await model.generateContent([
+          Content.text(prompt),
+        ], generationConfig: GenerationConfig(stopSequences: ['a']));
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
 
       test('can pass system instructions', () async {
         final instructions = 'Do a good job';
-        final (client, model) =
-            createModel(systemInstruction: Content.system(instructions));
+        final (client, model) = createModel(
+          systemInstruction: Content.system(instructions),
+        );
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'systemInstruction': {
               'role': 'system',
               'parts': [
-                {'text': instructions}
+                {'text': instructions},
               ],
             },
           },
@@ -325,49 +396,63 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
-        final response = await model.generateContent(
-          [Content.text(prompt)],
-        );
+        final response = await model.generateContent([Content.text(prompt)]);
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
 
       test('can pass tools and function calling config', () async {
         final (client, model) = createModel(
-            tools: [
-              Tool(functionDeclarations: [
-                FunctionDeclaration('someFunction', 'Some cool function.',
-                    Schema(SchemaType.string, description: 'Some parameter.'))
-              ])
-            ],
-            toolConfig: ToolConfig(
-                functionCallingConfig: FunctionCallingConfig(
-                    mode: FunctionCallingMode.any,
-                    allowedFunctionNames: {'someFunction'})));
+          tools: [
+            Tool(functionDeclarations: [
+              FunctionDeclaration(
+                'someFunction',
+                'Some cool function.',
+                Schema(SchemaType.string, description: 'Some parameter.'),
+              ),
+            ]),
+          ],
+          toolConfig: ToolConfig(
+            functionCallingConfig: FunctionCallingConfig(
+              mode: FunctionCallingMode.any,
+              allowedFunctionNames: {'someFunction'},
+            ),
+          ),
+        );
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'tools': [
               {
@@ -377,17 +462,17 @@ void main() {
                     'description': 'Some cool function.',
                     'parameters': {
                       'type': 'STRING',
-                      'description': 'Some parameter.'
-                    }
-                  }
-                ]
-              }
+                      'description': 'Some parameter.',
+                    },
+                  },
+                ],
+              },
             ],
             'toolConfig': {
               'functionCallingConfig': {
                 'mode': 'ANY',
                 'allowedFunctionNames': ['someFunction'],
-              }
+              },
             },
           },
           {
@@ -396,20 +481,28 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
         final response = await model.generateContent([Content.text(prompt)]);
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
 
       test('can override tools and function calling config', () async {
@@ -417,16 +510,18 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:generateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:generateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'tools': [
               {
@@ -436,17 +531,17 @@ void main() {
                     'description': 'Some cool function.',
                     'parameters': {
                       'type': 'STRING',
-                      'description': 'Some parameter.'
-                    }
-                  }
-                ]
-              }
+                      'description': 'Some parameter.',
+                    },
+                  },
+                ],
+              },
             ],
             'toolConfig': {
               'functionCallingConfig': {
                 'mode': 'ANY',
                 'allowedFunctionNames': ['someFunction'],
-              }
+              },
             },
           },
           {
@@ -455,32 +550,45 @@ void main() {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': result}
-                  ]
-                }
-              }
-            ]
+                    {'text': result},
+                  ],
+                },
+              },
+            ],
           },
         );
-        final response = await model.generateContent([
-          Content.text(prompt)
-        ],
-            tools: [
-              Tool(functionDeclarations: [
-                FunctionDeclaration('someFunction', 'Some cool function.',
-                    Schema(SchemaType.string, description: 'Some parameter.'))
-              ])
-            ],
-            toolConfig: ToolConfig(
-                functionCallingConfig: FunctionCallingConfig(
-                    mode: FunctionCallingMode.any,
-                    allowedFunctionNames: {'someFunction'})));
+        final response = await model.generateContent(
+          [Content.text(prompt)],
+          tools: [
+            Tool(functionDeclarations: [
+              FunctionDeclaration(
+                'someFunction',
+                'Some cool function.',
+                Schema(SchemaType.string, description: 'Some parameter.'),
+              ),
+            ]),
+          ],
+          toolConfig: ToolConfig(
+            functionCallingConfig: FunctionCallingConfig(
+              mode: FunctionCallingMode.any,
+              allowedFunctionNames: {'someFunction'},
+            ),
+          ),
+        );
         expect(
-            response,
-            matchesGenerateContentResponse(GenerateContentResponse([
+          response,
+          matchesGenerateContentResponse(
+            GenerateContentResponse([
               Candidate(
-                  Content('model', [TextPart(result)]), null, null, null, null),
-            ], null)));
+                Content('model', [TextPart(result)]),
+                null,
+                null,
+                null,
+                null,
+              ),
+            ], null),
+          ),
+        );
       });
     });
 
@@ -490,17 +598,19 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:streamGenerateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:streamGenerateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
-            ]
+                  {'text': prompt},
+                ],
+              },
+            ],
           },
           [
             for (final result in results)
@@ -510,24 +620,32 @@ void main() {
                     'content': {
                       'role': 'model',
                       'parts': [
-                        {'text': result}
-                      ]
-                    }
-                  }
-                ]
-              }
+                        {'text': result},
+                      ],
+                    },
+                  },
+                ],
+              },
           ],
         );
         final response = model.generateContentStream([Content.text(prompt)]);
         expect(
-            response,
-            emitsInOrder([
-              for (final result in results)
-                matchesGenerateContentResponse(GenerateContentResponse([
-                  Candidate(Content('model', [TextPart(result)]), null, null,
-                      null, null),
-                ], null))
-            ]));
+          response,
+          emitsInOrder([
+            for (final result in results)
+              matchesGenerateContentResponse(
+                GenerateContentResponse([
+                  Candidate(
+                    Content('model', [TextPart(result)]),
+                    null,
+                    null,
+                    null,
+                    null,
+                  ),
+                ], null),
+              ),
+          ]),
+        );
       });
 
       test('can override safety settings', () async {
@@ -535,22 +653,24 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:streamGenerateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:streamGenerateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'safetySettings': [
               {
                 'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
-                'threshold': 'BLOCK_ONLY_HIGH'
-              }
+                'threshold': 'BLOCK_ONLY_HIGH',
+              },
             ],
           },
           [
@@ -561,28 +681,40 @@ void main() {
                     'content': {
                       'role': 'model',
                       'parts': [
-                        {'text': result}
-                      ]
-                    }
-                  }
-                ]
-              }
+                        {'text': result},
+                      ],
+                    },
+                  },
+                ],
+              },
           ],
         );
-        final response = model.generateContentStream([
-          Content.text(prompt)
-        ], safetySettings: [
-          SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
-        ]);
+        final response = model.generateContentStream(
+          [Content.text(prompt)],
+          safetySettings: [
+            SafetySetting(
+              HarmCategory.dangerousContent,
+              HarmBlockThreshold.high,
+            ),
+          ],
+        );
         expect(
-            response,
-            emitsInOrder([
-              for (final result in results)
-                matchesGenerateContentResponse(GenerateContentResponse([
-                  Candidate(Content('model', [TextPart(result)]), null, null,
-                      null, null),
-                ], null))
-            ]));
+          response,
+          emitsInOrder([
+            for (final result in results)
+              matchesGenerateContentResponse(
+                GenerateContentResponse([
+                  Candidate(
+                    Content('model', [TextPart(result)]),
+                    null,
+                    null,
+                    null,
+                    null,
+                  ),
+                ], null),
+              ),
+          ]),
+        );
       });
 
       test('can override generation config', () async {
@@ -590,19 +722,21 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:streamGenerateContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:streamGenerateContent',
+          ),
           {
             'contents': [
               {
                 'role': 'user',
                 'parts': [
-                  {'text': prompt}
-                ]
-              }
+                  {'text': prompt},
+                ],
+              },
             ],
             'generationConfig': {
-              'stopSequences': ['a']
+              'stopSequences': ['a'],
             },
           },
           [
@@ -613,25 +747,34 @@ void main() {
                     'content': {
                       'role': 'model',
                       'parts': [
-                        {'text': result}
-                      ]
-                    }
-                  }
-                ]
-              }
+                        {'text': result},
+                      ],
+                    },
+                  },
+                ],
+              },
           ],
         );
-        final response = model.generateContentStream([Content.text(prompt)],
-            generationConfig: GenerationConfig(stopSequences: ['a']));
+        final response = model.generateContentStream([
+          Content.text(prompt),
+        ], generationConfig: GenerationConfig(stopSequences: ['a']));
         expect(
-            response,
-            emitsInOrder([
-              for (final result in results)
-                matchesGenerateContentResponse(GenerateContentResponse([
-                  Candidate(Content('model', [TextPart(result)]), null, null,
-                      null, null),
-                ], null))
-            ]));
+          response,
+          emitsInOrder([
+            for (final result in results)
+              matchesGenerateContentResponse(
+                GenerateContentResponse([
+                  Candidate(
+                    Content('model', [TextPart(result)]),
+                    null,
+                    null,
+                    null,
+                    null,
+                  ),
+                ], null),
+              ),
+          ]),
+        );
       });
     });
 
@@ -640,21 +783,22 @@ void main() {
         final (client, model) = createModel();
         final prompt = 'Some prompt';
         client.stub(
-            Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-                'models/some-model:countTokens'),
-            {
-              'contents': [
-                {
-                  'role': 'user',
-                  'parts': [
-                    {'text': prompt}
-                  ]
-                }
-              ]
-            },
-            {
-              'totalTokens': 2
-            });
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:countTokens',
+          ),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt},
+                ],
+              },
+            ],
+          },
+          {'totalTokens': 2},
+        );
         final response = await model.countTokens([Content.text(prompt)]);
         expect(response, matchesCountTokensResponse(CountTokensResponse(2)));
       });
@@ -665,27 +809,31 @@ void main() {
         final (client, model) = createModel();
         final prompt = 'Some prompt';
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:embedContent'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:embedContent',
+          ),
           {
             'content': {
               'role': 'user',
               'parts': [
-                {'text': prompt}
-              ]
-            }
+                {'text': prompt},
+              ],
+            },
           },
           {
             'embedding': {
-              'values': [0.1, 0.2, 0.3]
-            }
+              'values': [0.1, 0.2, 0.3],
+            },
           },
         );
         final response = await model.embedContent(Content.text(prompt));
         expect(
-            response,
-            matchesEmbedContentResponse(
-                EmbedContentResponse(ContentEmbedding([0.1, 0.2, 0.3]))));
+          response,
+          matchesEmbedContentResponse(
+            EmbedContentResponse(ContentEmbedding([0.1, 0.2, 0.3])),
+          ),
+        );
       });
     });
 
@@ -697,45 +845,52 @@ void main() {
         final embedding1 = [0.1, 0.2, 0.3];
         final embedding2 = [0.4, 0.5, 1.6];
         client.stub(
-          Uri.parse('https://generativelanguage.googleapis.com/v1beta/'
-              'models/some-model:batchEmbedContents'),
+          Uri.parse(
+            'https://generativelanguage.googleapis.com/v1beta/'
+            'models/some-model:batchEmbedContents',
+          ),
           {
             'requests': [
               {
                 'content': {
                   'role': 'user',
                   'parts': [
-                    {'text': prompt1}
-                  ]
+                    {'text': prompt1},
+                  ],
                 },
-                'model': 'models/$defaultModelName'
+                'model': 'models/$defaultModelName',
               },
               {
                 'content': {
                   'role': 'user',
                   'parts': [
-                    {'text': prompt2}
-                  ]
+                    {'text': prompt2},
+                  ],
                 },
-                'model': 'models/$defaultModelName'
-              }
-            ]
+                'model': 'models/$defaultModelName',
+              },
+            ],
           },
           {
             'embeddings': [
               {'values': embedding1},
-              {'values': embedding2}
-            ]
+              {'values': embedding2},
+            ],
           },
         );
         final response = await model.batchEmbedContents([
           EmbedContentRequest(Content.text(prompt1)),
-          EmbedContentRequest(Content.text(prompt2))
+          EmbedContentRequest(Content.text(prompt2)),
         ]);
         expect(
-            response,
-            matchesBatchEmbedContentsResponse(BatchEmbedContentsResponse(
-                [ContentEmbedding(embedding1), ContentEmbedding(embedding2)])));
+          response,
+          matchesBatchEmbedContentsResponse(
+            BatchEmbedContentsResponse([
+              ContentEmbedding(embedding1),
+              ContentEmbedding(embedding2),
+            ]),
+          ),
+        );
       });
     });
   });

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -28,24 +28,31 @@ void main() {
       final body = {'some': 'body'};
       final apiKey = 'apiKey';
       final expectedResponse = {'result': 'OK'};
-      await http.runWithClient(() async {
-        final client = HttpApiClient(apiKey: apiKey);
-        final response = await client.makeRequest(url, body);
-        expect(response, expectedResponse);
-      },
-          () => MockClient((request) async {
-                expect(
-                    request,
-                    matchesRequest(http.Request('POST', url)
-                      ..headers.addAll({
-                        'x-goog-api-key': apiKey,
-                        'x-goog-api-client': clientName,
-                        'Content-Type': 'application/json'
-                      })
-                      ..bodyBytes = utf8.encode(jsonEncode(body))));
-                return http.Response.bytes(
-                    utf8.encode(jsonEncode(expectedResponse)), 200);
-              }));
+      await http.runWithClient(
+        () async {
+          final client = HttpApiClient(apiKey: apiKey);
+          final response = await client.makeRequest(url, body);
+          expect(response, expectedResponse);
+        },
+        () => MockClient((request) async {
+          expect(
+            request,
+            matchesRequest(
+              http.Request('POST', url)
+                ..headers.addAll({
+                  'x-goog-api-key': apiKey,
+                  'x-goog-api-client': clientName,
+                  'Content-Type': 'application/json',
+                })
+                ..bodyBytes = utf8.encode(jsonEncode(body)),
+            ),
+          );
+          return http.Response.bytes(
+            utf8.encode(jsonEncode(expectedResponse)),
+            200,
+          );
+        }),
+      );
     });
 
     test('can make unary request with custom client', () async {
@@ -55,16 +62,21 @@ void main() {
       final expectedResponse = {'result': 'OK'};
       final httpClient = MockClient((request) async {
         expect(
-            request,
-            matchesRequest(http.Request('POST', url)
+          request,
+          matchesRequest(
+            http.Request('POST', url)
               ..headers.addAll({
                 'x-goog-api-key': apiKey,
                 'x-goog-api-client': clientName,
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
               })
-              ..bodyBytes = utf8.encode(jsonEncode(body))));
+              ..bodyBytes = utf8.encode(jsonEncode(body)),
+          ),
+        );
         return http.Response.bytes(
-            utf8.encode(jsonEncode(expectedResponse)), 200);
+          utf8.encode(jsonEncode(expectedResponse)),
+          200,
+        );
       });
       final client = HttpApiClient(apiKey: apiKey, httpClient: httpClient);
       final response = await client.makeRequest(url, body);
@@ -78,30 +90,41 @@ void main() {
       final apiKey = 'apiKey';
       final expectedResponses = [
         {'first': 'OK'},
-        {'second': 'OK'}
+        {'second': 'OK'},
       ];
-      await http.runWithClient(() async {
-        final client = HttpApiClient(apiKey: apiKey);
-        final response = client.streamRequest(url, body);
-        await expectLater(
-            response, emitsInOrder([...expectedResponses, emitsDone]));
-      },
-          () => MockClient.streaming((request, requestStream) async {
-                expect(
-                    request,
-                    matchesBaseRequest(http.Request('POST', streamingUrl)
-                      ..headers.addAll({
-                        'x-goog-api-key': apiKey,
-                        'x-goog-api-client': clientName,
-                        'Content-Type': 'application/json'
-                      })));
-                expect(requestStream,
-                    emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]));
-                return http.StreamedResponse(
-                    Stream.fromIterable(expectedResponses)
-                        .map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
-                    200);
-              }));
+      await http.runWithClient(
+        () async {
+          final client = HttpApiClient(apiKey: apiKey);
+          final response = client.streamRequest(url, body);
+          await expectLater(
+            response,
+            emitsInOrder([...expectedResponses, emitsDone]),
+          );
+        },
+        () => MockClient.streaming((request, requestStream) async {
+          expect(
+            request,
+            matchesBaseRequest(
+              http.Request('POST', streamingUrl)
+                ..headers.addAll({
+                  'x-goog-api-key': apiKey,
+                  'x-goog-api-client': clientName,
+                  'Content-Type': 'application/json',
+                }),
+            ),
+          );
+          expect(
+            requestStream,
+            emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]),
+          );
+          return http.StreamedResponse(
+            Stream.fromIterable(
+              expectedResponses,
+            ).map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
+            200,
+          );
+        }),
+      );
     });
 
     test('can make streaming request with custom client', () async {
@@ -111,28 +134,37 @@ void main() {
       final apiKey = 'apiKey';
       final expectedResponses = [
         {'first': 'OK'},
-        {'second': 'OK'}
+        {'second': 'OK'},
       ];
       final httpClient = MockClient.streaming((request, requestStream) async {
         expect(
-            request,
-            matchesBaseRequest(http.Request('POST', streamingUrl)
+          request,
+          matchesBaseRequest(
+            http.Request('POST', streamingUrl)
               ..headers.addAll({
                 'x-goog-api-key': apiKey,
                 'x-goog-api-client': clientName,
-                'Content-Type': 'application/json'
-              })));
-        expect(requestStream,
-            emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]));
+                'Content-Type': 'application/json',
+              }),
+          ),
+        );
+        expect(
+          requestStream,
+          emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]),
+        );
         return http.StreamedResponse(
-            Stream.fromIterable(expectedResponses)
-                .map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
-            200);
+          Stream.fromIterable(
+            expectedResponses,
+          ).map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
+          200,
+        );
       });
       final client = HttpApiClient(apiKey: apiKey, httpClient: httpClient);
       final response = client.streamRequest(url, body);
       await expectLater(
-          response, emitsInOrder([...expectedResponses, emitsDone]));
+        response,
+        emitsInOrder([...expectedResponses, emitsDone]),
+      );
     });
 
     test('parses non-SSE JSON error object at the top level', () async {
@@ -141,27 +173,33 @@ void main() {
       final body = {'some': 'body'};
       final apiKey = 'apiKey';
       final expectedError = {
-        'error': {'message': 'User location is not supported for the API use.'}
+        'error': {'message': 'User location is not supported for the API use.'},
       };
-      await http.runWithClient(() async {
-        final client = HttpApiClient(apiKey: apiKey);
-        final response = client.streamRequest(url, body);
-        await expectLater(response, emitsInOrder([expectedError, emitsDone]));
-      },
-          () => MockClient.streaming((request, requestStream) async {
-                expect(
-                    request,
-                    matchesBaseRequest(http.Request('POST', streamingUrl)
-                      ..headers.addAll({
-                        'x-goog-api-key': apiKey,
-                        'x-goog-api-client': clientName,
-                        'Content-Type': 'application/json'
-                      })));
-                return http.StreamedResponse(
-                    // No "data: " prefix
-                    Stream.value(utf8.encode(jsonEncode(expectedError))),
-                    400);
-              }));
+      await http.runWithClient(
+        () async {
+          final client = HttpApiClient(apiKey: apiKey);
+          final response = client.streamRequest(url, body);
+          await expectLater(response, emitsInOrder([expectedError, emitsDone]));
+        },
+        () => MockClient.streaming((request, requestStream) async {
+          expect(
+            request,
+            matchesBaseRequest(
+              http.Request('POST', streamingUrl)
+                ..headers.addAll({
+                  'x-goog-api-key': apiKey,
+                  'x-goog-api-client': clientName,
+                  'Content-Type': 'application/json',
+                }),
+            ),
+          );
+          return http.StreamedResponse(
+            // No "data: " prefix
+            Stream.value(utf8.encode(jsonEncode(expectedError))),
+            400,
+          );
+        }),
+      );
     });
   });
 }

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -55,9 +55,15 @@ void main() {
 ''';
       final decoded = jsonDecode(response) as Object;
       expect(
-          () => parseGenerateContentResponse(decoded),
-          throwsA(isA<FormatException>().having((e) => e.message, 'message',
-              startsWith('Unhandled Content format'))));
+        () => parseGenerateContentResponse(decoded),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            startsWith('Unhandled Content format'),
+          ),
+        ),
+      );
     });
 
     test('with a blocked prompt', () {
@@ -89,22 +95,35 @@ void main() {
       final decoded = jsonDecode(response) as Object;
       final generateContentResponse = parseGenerateContentResponse(decoded);
       expect(
-          generateContentResponse,
-          matchesGenerateContentResponse(GenerateContentResponse(
-              [],
-              PromptFeedback(BlockReason.safety, null, [
-                SafetyRating(
-                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
-                SafetyRating(HarmCategory.hateSpeech, HarmProbability.high),
-                SafetyRating(
-                    HarmCategory.harassment, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.dangerousContent, HarmProbability.negligible),
-              ]))));
+        generateContentResponse,
+        matchesGenerateContentResponse(
+          GenerateContentResponse(
+            [],
+            PromptFeedback(BlockReason.safety, null, [
+              SafetyRating(
+                HarmCategory.sexuallyExplicit,
+                HarmProbability.negligible,
+              ),
+              SafetyRating(HarmCategory.hateSpeech, HarmProbability.high),
+              SafetyRating(HarmCategory.harassment, HarmProbability.negligible),
+              SafetyRating(
+                HarmCategory.dangerousContent,
+                HarmProbability.negligible,
+              ),
+            ]),
+          ),
+        ),
+      );
       expect(
-          () => generateContentResponse.text,
-          throwsA(isA<GenerativeAIException>().having((e) => e.message,
-              'message', startsWith('Response was blocked due to safety'))));
+        () => generateContentResponse.text,
+        throwsA(
+          isA<GenerativeAIException>().having(
+            (e) => e.message,
+            'message',
+            startsWith('Response was blocked due to safety'),
+          ),
+        ),
+      );
     });
   });
 
@@ -169,36 +188,52 @@ void main() {
       final decoded = jsonDecode(response) as Object;
       final generateContentResponse = parseGenerateContentResponse(decoded);
       expect(
-          generateContentResponse,
-          matchesGenerateContentResponse(GenerateContentResponse(
-              [
-                Candidate(
-                    Content.model(
-                        [TextPart('Mountain View, California, United States')]),
-                    [
-                      SafetyRating(HarmCategory.sexuallyExplicit,
-                          HarmProbability.negligible),
-                      SafetyRating(
-                          HarmCategory.hateSpeech, HarmProbability.negligible),
-                      SafetyRating(
-                          HarmCategory.harassment, HarmProbability.negligible),
-                      SafetyRating(HarmCategory.dangerousContent,
-                          HarmProbability.negligible),
-                    ],
-                    null,
-                    FinishReason.stop,
-                    null),
-              ],
-              PromptFeedback(null, null, [
-                SafetyRating(
-                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.hateSpeech, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.harassment, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.dangerousContent, HarmProbability.negligible),
-              ]))));
+        generateContentResponse,
+        matchesGenerateContentResponse(
+          GenerateContentResponse(
+            [
+              Candidate(
+                Content.model([
+                  TextPart('Mountain View, California, United States'),
+                ]),
+                [
+                  SafetyRating(
+                    HarmCategory.sexuallyExplicit,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.hateSpeech,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.harassment,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.dangerousContent,
+                    HarmProbability.negligible,
+                  ),
+                ],
+                null,
+                FinishReason.stop,
+                null,
+              ),
+            ],
+            PromptFeedback(null, null, [
+              SafetyRating(
+                HarmCategory.sexuallyExplicit,
+                HarmProbability.negligible,
+              ),
+              SafetyRating(HarmCategory.hateSpeech, HarmProbability.negligible),
+              SafetyRating(HarmCategory.harassment, HarmProbability.negligible),
+              SafetyRating(
+                HarmCategory.dangerousContent,
+                HarmProbability.negligible,
+              ),
+            ]),
+          ),
+        ),
+      );
     });
 
     test('with a citation', () async {
@@ -286,40 +321,53 @@ void main() {
       final decoded = jsonDecode(response) as Object;
       final generateContentResponse = parseGenerateContentResponse(decoded);
       expect(
-          generateContentResponse,
-          matchesGenerateContentResponse(GenerateContentResponse(
-              [
-                Candidate(
-                    Content.model([TextPart('placeholder')]),
-                    [
-                      SafetyRating(HarmCategory.sexuallyExplicit,
-                          HarmProbability.negligible),
-                      SafetyRating(
-                          HarmCategory.hateSpeech, HarmProbability.negligible),
-                      SafetyRating(
-                          HarmCategory.harassment, HarmProbability.negligible),
-                      SafetyRating(HarmCategory.dangerousContent,
-                          HarmProbability.negligible),
-                    ],
-                    CitationMetadata([
-                      CitationSource(
-                          574, 705, Uri.https('example.com', ''), ''),
-                      CitationSource(
-                          899, 1026, Uri.https('example.com', ''), ''),
-                    ]),
-                    FinishReason.stop,
-                    null),
-              ],
-              PromptFeedback(null, null, [
-                SafetyRating(
-                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.hateSpeech, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.harassment, HarmProbability.negligible),
-                SafetyRating(
-                    HarmCategory.dangerousContent, HarmProbability.negligible),
-              ]))));
+        generateContentResponse,
+        matchesGenerateContentResponse(
+          GenerateContentResponse(
+            [
+              Candidate(
+                Content.model([TextPart('placeholder')]),
+                [
+                  SafetyRating(
+                    HarmCategory.sexuallyExplicit,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.hateSpeech,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.harassment,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.dangerousContent,
+                    HarmProbability.negligible,
+                  ),
+                ],
+                CitationMetadata([
+                  CitationSource(574, 705, Uri.https('example.com', ''), ''),
+                  CitationSource(899, 1026, Uri.https('example.com', ''), ''),
+                ]),
+                FinishReason.stop,
+                null,
+              ),
+            ],
+            PromptFeedback(null, null, [
+              SafetyRating(
+                HarmCategory.sexuallyExplicit,
+                HarmProbability.negligible,
+              ),
+              SafetyRating(HarmCategory.hateSpeech, HarmProbability.negligible),
+              SafetyRating(HarmCategory.harassment, HarmProbability.negligible),
+              SafetyRating(
+                HarmCategory.dangerousContent,
+                HarmProbability.negligible,
+              ),
+            ]),
+          ),
+        ),
+      );
     });
 
     test('allows missing content', () async {
@@ -356,27 +404,27 @@ void main() {
       expect(
         generateContentResponse,
         matchesGenerateContentResponse(
-          GenerateContentResponse(
-            [
-              Candidate(
+          GenerateContentResponse([
+            Candidate(
                 Content(null, []),
                 [
-                  SafetyRating(HarmCategory.sexuallyExplicit,
-                      HarmProbability.negligible),
+                  SafetyRating(
+                    HarmCategory.sexuallyExplicit,
+                    HarmProbability.negligible,
+                  ),
                   SafetyRating(
                       HarmCategory.hateSpeech, HarmProbability.negligible),
                   SafetyRating(
                       HarmCategory.harassment, HarmProbability.negligible),
-                  SafetyRating(HarmCategory.dangerousContent,
-                      HarmProbability.negligible),
+                  SafetyRating(
+                    HarmCategory.dangerousContent,
+                    HarmProbability.negligible,
+                  ),
                 ],
                 CitationMetadata([]),
                 FinishReason.safety,
-                null,
-              ),
-            ],
-            null,
-          ),
+                null),
+          ], null),
         ),
       );
     });
@@ -408,10 +456,13 @@ void main() {
 }
 ''';
       final decoded = jsonDecode(response) as Object;
-      final expectedThrow = throwsA(isA<InvalidApiKey>().having(
+      final expectedThrow = throwsA(
+        isA<InvalidApiKey>().having(
           (e) => e.message,
           'message',
-          'API key not valid. Please pass a valid API key.'));
+          'API key not valid. Please pass a valid API key.',
+        ),
+      );
       expect(() => parseGenerateContentResponse(decoded), expectedThrow);
       expect(() => parseCountTokensResponse(decoded), expectedThrow);
       expect(() => parseEmbedContentResponse(decoded), expectedThrow);
@@ -434,10 +485,13 @@ void main() {
 }
 ''';
       final decoded = jsonDecode(response) as Object;
-      final expectedThrow = throwsA(isA<UnsupportedUserLocation>().having(
+      final expectedThrow = throwsA(
+        isA<UnsupportedUserLocation>().having(
           (e) => e.message,
           'message',
-          'User location is not supported for the API use.'));
+          'User location is not supported for the API use.',
+        ),
+      );
       expect(() => parseGenerateContentResponse(decoded), expectedThrow);
       expect(() => parseCountTokensResponse(decoded), expectedThrow);
       expect(() => parseEmbedContentResponse(decoded), expectedThrow);
@@ -460,11 +514,16 @@ void main() {
 }
 ''';
       final decoded = jsonDecode(response) as Object;
-      final expectedThrow = throwsA(isA<ServerException>().having(
+      final expectedThrow = throwsA(
+        isA<ServerException>().having(
           (e) => e.message,
           'message',
-          startsWith('models/unknown is not found for API version v1, '
-              'or is not supported for GenerateContent.')));
+          startsWith(
+            'models/unknown is not found for API version v1, '
+            'or is not supported for GenerateContent.',
+          ),
+        ),
+      );
       expect(() => parseGenerateContentResponse(decoded), expectedThrow);
       expect(() => parseCountTokensResponse(decoded), expectedThrow);
       expect(() => parseEmbedContentResponse(decoded), expectedThrow);

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -47,30 +47,43 @@ Matcher matchesContent(Content content) => isA<Content>()
     .having((c) => c.role, 'role', content.role)
     .having((c) => c.parts, 'parts', content.parts.map(matchesPart).toList());
 
-Matcher matchesCandidate(Candidate candidate) => isA<Candidate>()
-    .having((c) => c.content, 'content', matchesContent(candidate.content));
+Matcher matchesCandidate(Candidate candidate) => isA<Candidate>().having(
+      (c) => c.content,
+      'content',
+      matchesContent(candidate.content),
+    );
 
 Matcher matchesGenerateContentResponse(GenerateContentResponse response) =>
     isA<GenerateContentResponse>()
-        .having((r) => r.candidates, 'candidates',
-            response.candidates.map(matchesCandidate).toList())
         .having(
-            (r) => r.promptFeedback,
-            'promptFeedback',
-            response.promptFeedback == null
-                ? isNull
-                : matchesPromptFeedback(response.promptFeedback!));
+          (r) => r.candidates,
+          'candidates',
+          response.candidates.map(matchesCandidate).toList(),
+        )
+        .having(
+          (r) => r.promptFeedback,
+          'promptFeedback',
+          response.promptFeedback == null
+              ? isNull
+              : matchesPromptFeedback(response.promptFeedback!),
+        );
 
-Matcher matchesPromptFeedback(PromptFeedback promptFeedback) =>
+Matcher matchesPromptFeedback(
+  PromptFeedback promptFeedback,
+) =>
     isA<PromptFeedback>()
         .having((p) => p.blockReason, 'blockReason', promptFeedback.blockReason)
-        .having((p) => p.blockReasonMessage, 'blockReasonMessage',
-            promptFeedback.blockReasonMessage)
         .having(
-            (p) => p.safetyRatings,
-            'safetyRatings',
-            unorderedMatches(
-                promptFeedback.safetyRatings.map(matchesSafetyRating)));
+          (p) => p.blockReasonMessage,
+          'blockReasonMessage',
+          promptFeedback.blockReasonMessage,
+        )
+        .having(
+          (p) => p.safetyRatings,
+          'safetyRatings',
+          unorderedMatches(
+              promptFeedback.safetyRatings.map(matchesSafetyRating)),
+        );
 
 Matcher matchesSafetyRating(SafetyRating safetyRating) => isA<SafetyRating>()
     .having((s) => s.category, 'category', safetyRating.category)
@@ -81,16 +94,26 @@ Matcher matchesEmbedding(ContentEmbedding embedding) =>
 
 Matcher matchesEmbedContentResponse(EmbedContentResponse response) =>
     isA<EmbedContentResponse>().having(
-        (r) => r.embedding, 'embedding', matchesEmbedding(response.embedding));
+      (r) => r.embedding,
+      'embedding',
+      matchesEmbedding(response.embedding),
+    );
 
 Matcher matchesBatchEmbedContentsResponse(
-        BatchEmbedContentsResponse response) =>
-    isA<BatchEmbedContentsResponse>().having((r) => r.embeddings, 'embeddings',
-        response.embeddings.map(matchesEmbedding));
+  BatchEmbedContentsResponse response,
+) =>
+    isA<BatchEmbedContentsResponse>().having(
+      (r) => r.embeddings,
+      'embeddings',
+      response.embeddings.map(matchesEmbedding),
+    );
 
 Matcher matchesCountTokensResponse(CountTokensResponse response) =>
-    isA<CountTokensResponse>()
-        .having((r) => r.totalTokens, 'totalTokens', response.totalTokens);
+    isA<CountTokensResponse>().having(
+      (r) => r.totalTokens,
+      'totalTokens',
+      response.totalTokens,
+    );
 
 Matcher matchesRequest(http.Request request) => isA<http.Request>()
     .having((r) => r.headers, 'headers', request.headers)

--- a/pkgs/google_generative_ai/test/utils/stub_client.dart
+++ b/pkgs/google_generative_ai/test/utils/stub_client.dart
@@ -15,33 +15,47 @@
 import 'package:collection/collection.dart';
 import 'package:google_generative_ai/src/client.dart';
 
-const Equality<Map<String, Object?>> _mapEquality =
-    MapEquality(values: DeepCollectionEquality());
+const Equality<Map<String, Object?>> _mapEquality = MapEquality(
+  values: DeepCollectionEquality(),
+);
 
 final class StubClient implements ApiClient {
-  final _requests =
-      EqualityMap<Map<String, Object?>, Map<String, Object?>>(_mapEquality);
+  final _requests = EqualityMap<Map<String, Object?>, Map<String, Object?>>(
+    _mapEquality,
+  );
   final _streamRequests =
       EqualityMap<Map<String, Object?>, Iterable<Map<String, Object?>>>(
-          _mapEquality);
+    _mapEquality,
+  );
 
   void stub(Uri uri, Map<String, Object?> body, Map<String, Object?> result) =>
       _requests[{'_hack_uri': uri, ...body}] = result;
-  void stubStream(Uri uri, Map<String, Object?> body,
-          Iterable<Map<String, Object?>> result) =>
+  void stubStream(
+    Uri uri,
+    Map<String, Object?> body,
+    Iterable<Map<String, Object?>> result,
+  ) =>
       _streamRequests[{'_hack_uri': uri, ...body}] = result;
 
   @override
   Future<Map<String, Object?>> makeRequest(
-          Uri uri, Map<String, Object?> body) =>
-      Future.value(_requests.remove({'_hack_uri': uri, ...body}) ??
-          (throw StateError(
-              'Missing stub for request to $uri with body $body')));
+    Uri uri,
+    Map<String, Object?> body,
+  ) =>
+      Future.value(
+        _requests.remove({'_hack_uri': uri, ...body}) ??
+            (throw StateError(
+                'Missing stub for request to $uri with body $body')),
+      );
 
   @override
   Stream<Map<String, Object?>> streamRequest(
-          Uri uri, Map<String, Object?> body) =>
-      Stream.fromIterable(_streamRequests.remove({'_hack_uri': uri, ...body}) ??
-          (throw StateError(
-              'Missing stub for request to $uri with body $body')));
+    Uri uri,
+    Map<String, Object?> body,
+  ) =>
+      Stream.fromIterable(
+        _streamRequests.remove({'_hack_uri': uri, ...body}) ??
+            (throw StateError(
+                'Missing stub for request to $uri with body $body')),
+      );
 }


### PR DESCRIPTION
An upcoming test refactor looks better when it's formatted with trailing
commas in more places. Pre-emptively format with inserted trailing
commas to make it easier to automate the formatting and reduce the diff
in the test refactor.

Trailing commas are inserted automatically by first formatting with the
`tall-style` experiment against the latest commit of `dart_style`, then
reformatting with the stable SDK to match CI expectations. The result
is the current formatting, with the trailing commas inferred where the
tall style has improved splitting. Blank lines are restored following
license header comments.
