### PR TITLE
Unseal the Part class

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.4-wip
+## 0.4.0
 
 - Add support for parsing Vertex AI specific fields in `CountTokensResponse`.
 - Add named constructors on `Schema` for each value type.
@@ -6,6 +6,8 @@
   `'application/json'` to force the model to reply with JSON parseable output.
 - Add `outputDimensionality` argument support for `embedContent` and
   `batchEmbedContent`.
+- **Breaking** The `Part` class is no longer `sealed`. Exhaustive switches over
+  a `Part` instance will need to add a wildcard case.
 
 ## 0.3.3
 

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -80,7 +80,7 @@ Part _parsePart(Object? jsonObject) {
 }
 
 /// A datatype containing media that is part of a multi-part [Content] message.
-sealed class Part {
+abstract interface class Part {
   Object toJson();
 }
 

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.4-wip';
+const packageVersion = '0.4.0-wip';

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.0-wip';
+const packageVersion = '0.4.0';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.4-wip
+version: 0.4.0
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -41,6 +41,7 @@ Matcher matchesPart(Part part) => switch (part) {
             // TODO: When updating min SDK remove ignore.
             // ignore: unused_result, implementation bug
             .having((p) => p.response, 'args', response),
+      _ => throw StateError('Unhandled Part type.'),
     };
 
 Matcher matchesContent(Content content) => isA<Content>()


### PR DESCRIPTION
The vertex AI SDK will need new subtypes for parts which are not used on
the Google AI API. For instance in vertex referring to uploaded files
includes both the Uri and a mimetype, while on Google AI an uploaded
file stores it's own mime type and the Part only includes the Uri.

Prepare to publish to keep vertex unblocked.
