### PR TITLE
Add Content.functionResponses utility

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -6,6 +6,8 @@
   `'application/json'` to force the model to reply with JSON parseable output.
 - Add `outputDimensionality` argument support for `embedContent` and
   `batchEmbedContent`.
+- Add `Content.functionResponses` utility to reply to multiple function calls in
+  parallel.
 - **Breaking** The `Part` class is no longer `sealed`. Exhaustive switches over
   a `Part` instance will need to add a wildcard case.
 

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -38,6 +38,8 @@ final class Content {
   static Content functionResponse(
           String name, Map<String, Object?>? response) =>
       Content('function', [FunctionResponse(name, response)]);
+  static Content functionResponses(Iterable<FunctionResponse> responses) =>
+      Content('function', responses.toList());
   static Content system(String instructions) =>
       Content('system', [TextPart(instructions)]);
 


### PR DESCRIPTION
The alternative when replying to multiple functions in parallel is to
use the `Content` constructor and pass the string `'function'` to the
`role` parameter. Use a static method to obscure the role string for
consistency with the others.

Update sample with a demonstration of replying to all function calls.
