### PR TITLE
Join multiple text parts in the text getter

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1-wip
+
+- Concatenate multiple `TextPart` into the `text` String in case the model
+  replies with more than one part.
+
 ## 0.4.0
 
 - Add support for parsing Vertex AI specific fields in `CountTokensResponse`.

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -57,17 +57,17 @@ final class GenerateContentResponse {
     this.usageMetadata,
   });
 
-  /// The text content of the first part of the first of [candidates], if any.
+  /// The text content of the text parts of the first of [candidates], if any.
   ///
   /// If the prompt was blocked, or the first candidate was finished for a reason
   /// of [FinishReason.recitation] or [FinishReason.safety], accessing this text
   /// will throw a [GenerativeAIException].
   ///
-  /// If the first candidate's content starts with a text part, this value is
-  /// that text.
+  /// If the first candidate's content contains any text parts, this value is
+  /// the concatenation of the text.
   ///
-  /// If there are no candidates, or if the first candidate does not start with
-  /// a text part, this value is `null`.
+  /// If there are no candidates, or if the first candidate does not contain any
+  /// text parts, this value is `null`.
   String? get text {
     return switch (candidates) {
       [] => switch (promptFeedback) {
@@ -96,8 +96,12 @@ final class GenerateContentResponse {
                   ? ': $finishMessage'
                   : ''),
         ),
+      // Special case for a single TextPart to avoid iterable chain.
       [Candidate(content: Content(parts: [TextPart(:final text)])), ...] =>
         text,
+      [Candidate(content: Content(:final parts)), ...]
+          when parts.any((p) => p is TextPart) =>
+        parts.whereType<TextPart>().map((p) => p.text).join(''),
       [Candidate(), ...] => null,
     };
   }

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.0';
+const packageVersion = '0.4.1-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.0
+version: 0.4.1-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -428,6 +428,36 @@ void main() {
         ),
       );
     });
+
+    test('text getter joins content', () async {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Initial text"
+          },
+          {
+            "functionCall": {"name": "someFunction", "args": {}}
+          },
+          {
+            "text": " And more text"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(generateContentResponse.text, 'Initial text And more text');
+    });
   });
 
   group('parses and throws error responses', () {


### PR DESCRIPTION
Prepare for cases where the model may reply with both text and a
function call.

When the text getter was introduced the cross-SDK approach was to return
the first text part. Now that multiple parts are more common with
function calling we decided to switch to concatenating the text.

I think this should be non-breaking in practice because current models
don't seem to respond with a text part when it isn't the single part.
