### PR TITLE
Fix Schema.number and Schema.integer factories ignoring format field

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Concatenate multiple `TextPart` into the `text` String in case the model
   replies with more than one part.
+- Fix handling of `format` argument to `Schema.number` and `Schema.integer`.
 
 ## 0.4.0
 

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -211,6 +211,7 @@ final class Schema {
           SchemaType.number,
           description: description,
           nullable: nullable,
+          format: format,
         );
 
   /// Construct a schema for an integer number.
@@ -224,6 +225,7 @@ final class Schema {
           SchemaType.integer,
           description: description,
           nullable: nullable,
+          format: format,
         );
 
   /// Construct a schema for bool value.


### PR DESCRIPTION
The `format` field was being ignored when using `Schema.number`or `Schema.integer` factories.