### PR TITLE
Export UsageMetadata from the main library

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Concatenate multiple `TextPart` into the `text` String in case the model
   replies with more than one part.
 - Fix handling of `format` argument to `Schema.number` and `Schema.integer`.
+- Export `UsageMetadata`.
 
 ## 0.4.0
 

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -57,7 +57,8 @@ export 'src/api.dart'
         PromptFeedback,
         SafetyRating,
         SafetySetting,
-        TaskType;
+        TaskType,
+        UsageMetadata;
 export 'src/chat.dart' show ChatSession, StartChatExtension;
 export 'src/content.dart'
     show


### PR DESCRIPTION
This is a public field in `GenerateContentResponse` and was missed in
the export in #143. Resolves the missing API for vertex in #165.
