### PR TITLE
Include full GenerateContentRequest for countTokens

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -4,11 +4,9 @@
   replies with more than one part.
 - Fix handling of `format` argument to `Schema.number` and `Schema.integer`.
 - Export `UsageMetadata`.
-- Include the full `GenerateContentRequest` (previously omitted
-  `safetySettings`, `generationConfig`, `tools`, `toolConfig`, and
-  `systemInstruction`) in `countTokens` requests. This aligns the token count
-  with token count the backend will see in practice if it was a
-  `generateContent` request.
+- Include more fields from `GenerateContentRequest` (previously omitted
+  `safetySettings`, `tools`, `toolConfig`, and `systemInstruction`) in
+  `countTokens` requests.
 
 ## 0.4.0
 

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -4,9 +4,11 @@
   replies with more than one part.
 - Fix handling of `format` argument to `Schema.number` and `Schema.integer`.
 - Export `UsageMetadata`.
-- Include more fields from `GenerateContentRequest` (previously omitted
-  `safetySettings`, `tools`, `toolConfig`, and `systemInstruction`) in
-  `countTokens` requests.
+- Include the full `GenerateContentRequest` (previously omitted
+  `safetySettings`, `generationConfig`, `tools`, `toolConfig`, and
+  `systemInstruction`) in `countTokens` requests. This aligns the token count
+  with token count the backend will see in practice if it was a
+  `generateContent` request.
 
 ## 0.4.0
 

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -4,6 +4,11 @@
   replies with more than one part.
 - Fix handling of `format` argument to `Schema.number` and `Schema.integer`.
 - Export `UsageMetadata`.
+- Include the full `GenerateContentRequest` (previously omitted
+  `safetySettings`, `generationConfig`, `tools`, `toolConfig`, and
+  `systemInstruction`) in `countTokens` requests. This aligns the token count
+  with token count the backend will see in practice if it was a
+  `generateContent` request.
 
 ## 0.4.0
 

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Include the full `GenerateContentRequest` (previously omitted
   `safetySettings`, `generationConfig`, `tools`, `toolConfig`, and
   `systemInstruction`) in `countTokens` requests. This aligns the token count
-  with token count the backend will see in practice if it was a
+  with the token count the backend will see in practice for a
   `generateContent` request.
 
 ## 0.4.0

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -241,6 +241,7 @@ final class GenerativeModel {
   Future<CountTokensResponse> countTokens(
     Iterable<Content> contents, {
     List<SafetySetting>? safetySettings,
+    GenerationConfig? generationConfig,
     List<Tool>? tools,
     ToolConfig? toolConfig,
   }) async {
@@ -249,9 +250,9 @@ final class GenerativeModel {
         _generateContentRequest(
           contents,
           safetySettings: safetySettings,
+          generationConfig: generationConfig,
           tools: tools,
           toolConfig: toolConfig,
-          includeGenerationConfig: false,
         ));
     return parseCountTokensResponse(response);
   }
@@ -312,7 +313,6 @@ final class GenerativeModel {
     GenerationConfig? generationConfig,
     List<Tool>? tools,
     ToolConfig? toolConfig,
-    bool includeGenerationConfig = true,
   }) {
     safetySettings ??= _safetySettings;
     generationConfig ??= _generationConfig;
@@ -322,7 +322,7 @@ final class GenerativeModel {
       'contents': contents.map((c) => c.toJson()).toList(),
       if (safetySettings.isNotEmpty)
         'safetySettings': safetySettings.map((s) => s.toJson()).toList(),
-      if (includeGenerationConfig && generationConfig != null)
+      if (generationConfig != null)
         'generationConfig': generationConfig.toJson(),
       if (tools != null) 'tools': tools.map((t) => t.toJson()).toList(),
       if (toolConfig != null) 'toolConfig': toolConfig.toJson(),

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -241,7 +241,6 @@ final class GenerativeModel {
   Future<CountTokensResponse> countTokens(
     Iterable<Content> contents, {
     List<SafetySetting>? safetySettings,
-    GenerationConfig? generationConfig,
     List<Tool>? tools,
     ToolConfig? toolConfig,
   }) async {
@@ -250,9 +249,9 @@ final class GenerativeModel {
         _generateContentRequest(
           contents,
           safetySettings: safetySettings,
-          generationConfig: generationConfig,
           tools: tools,
           toolConfig: toolConfig,
+          includeGenerationConfig: false,
         ));
     return parseCountTokensResponse(response);
   }
@@ -313,6 +312,7 @@ final class GenerativeModel {
     GenerationConfig? generationConfig,
     List<Tool>? tools,
     ToolConfig? toolConfig,
+    bool includeGenerationConfig = true,
   }) {
     safetySettings ??= _safetySettings;
     generationConfig ??= _generationConfig;
@@ -322,7 +322,7 @@ final class GenerativeModel {
       'contents': contents.map((c) => c.toJson()).toList(),
       if (safetySettings.isNotEmpty)
         'safetySettings': safetySettings.map((s) => s.toJson()).toList(),
-      if (generationConfig != null)
+      if (includeGenerationConfig && generationConfig != null)
         'generationConfig': generationConfig.toJson(),
       if (tools != null) 'tools': tools.map((t) => t.toJson()).toList(),
       if (toolConfig != null) 'toolConfig': toolConfig.toJson(),

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -221,10 +221,10 @@ final class GenerativeModel {
   /// Sends a "countTokens" API request for the configured model,
   /// and waits for the response.
   ///
-  /// The [safetySettings], [tools], and [toolConfig], override the arguments of
-  /// the same name passed to the [GenerativeModel.new] constructor. Each
-  /// argument, when non-null, overrides the model level configuration in its
-  /// entirety.
+  /// The [safetySettings], [generationConfig], [tools], and [toolConfig],
+  /// override the arguments of the same name passed to the
+  /// [GenerativeModel.new] constructor. Each argument, when non-null,
+  /// overrides the model level configuration in its entirety.
   ///
   /// Example:
   /// ```dart

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -221,10 +221,10 @@ final class GenerativeModel {
   /// Sends a "countTokens" API request for the configured model,
   /// and waits for the response.
   ///
-  /// The [safetySettings], [generationConfig], [tools], and [toolConfig],
-  /// override the arguments of the same name passed to the
-  /// [GenerativeModel.new] constructor. Each argument, when non-null,
-  /// overrides the model level configuration in its entirety.
+  /// The [safetySettings], [tools], and [toolConfig], override the arguments of
+  /// the same name passed to the [GenerativeModel.new] constructor. Each
+  /// argument, when non-null, overrides the model level configuration in its
+  /// entirety.
   ///
   /// Example:
   /// ```dart

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -245,15 +245,15 @@ final class GenerativeModel {
     List<Tool>? tools,
     ToolConfig? toolConfig,
   }) async {
-    final response = await _client.makeRequest(
-        _taskUri(Task.countTokens),
-        _generateContentRequest(
-          contents,
-          safetySettings: safetySettings,
-          generationConfig: generationConfig,
-          tools: tools,
-          toolConfig: toolConfig,
-        ));
+    final response = await _client.makeRequest(_taskUri(Task.countTokens), {
+      'generateContentRequest': _generateContentRequest(
+        contents,
+        safetySettings: safetySettings,
+        generationConfig: generationConfig,
+        tools: tools,
+        toolConfig: toolConfig,
+      )
+    });
     return parseCountTokensResponse(response);
   }
 
@@ -319,6 +319,7 @@ final class GenerativeModel {
     tools ??= _tools;
     toolConfig ??= _toolConfig;
     return {
+      'model': '${_model.prefix}/${_model.name}',
       'contents': contents.map((c) => c.toJson()).toList(),
       if (safetySettings.isNotEmpty)
         'safetySettings': safetySettings.map((s) => s.toJson()).toList(),

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -26,6 +26,7 @@ void main() {
       String modelName = defaultModelName,
       RequestOptions? requestOptions,
       Content? systemInstruction,
+      GenerationConfig? generationConfig,
       List<Tool>? tools,
       ToolConfig? toolConfig,
     }) {
@@ -35,6 +36,7 @@ void main() {
         client: client.client,
         requestOptions: requestOptions,
         systemInstruction: systemInstruction,
+        generationConfig: generationConfig,
         tools: tools,
         toolConfig: toolConfig,
       );
@@ -443,7 +445,6 @@ void main() {
                 HarmBlockThreshold.high,
               ),
             ],
-            generationConfig: GenerationConfig(stopSequences: ['a']),
             tools: [
               Tool(functionDeclarations: [
                 FunctionDeclaration(
@@ -467,9 +468,6 @@ void main() {
                 'threshold': 'BLOCK_ONLY_HIGH',
               },
             ]);
-            expect(request['generationConfig'], {
-              'stopSequences': ['a'],
-            });
             expect(request['tools'], [
               {
                 'functionDeclarations': [
@@ -490,6 +488,19 @@ void main() {
                 'allowedFunctionNames': ['someFunction'],
               },
             });
+          },
+        );
+      });
+
+      test('excludes generationConfig', () async {
+        final (client, model) = createModel(
+            generationConfig: GenerationConfig(maxOutputTokens: 1000));
+        final prompt = 'Some prompt';
+        await client.checkRequest(
+          response: {'totalTokens': 100},
+          () => model.countTokens([Content.text(prompt)]),
+          verifyRequest: (_, request) {
+            expect(request, isNot(contains('generationConfig')));
           },
         );
       });

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -99,6 +99,7 @@ void main() {
               ),
             );
             expect(request, {
+              'model': 'models/$defaultModelName',
               'contents': [
                 {
                   'role': 'user',
@@ -311,6 +312,7 @@ void main() {
               ),
             );
             expect(request, {
+              'model': 'models/$defaultModelName',
               'contents': [
                 {
                   'role': 'user',
@@ -415,14 +417,17 @@ void main() {
               ),
             );
             expect(request, {
-              'contents': [
-                {
-                  'role': 'user',
-                  'parts': [
-                    {'text': prompt},
-                  ],
-                },
-              ],
+              'generateContentRequest': {
+                'model': 'models/$defaultModelName',
+                'contents': [
+                  {
+                    'role': 'user',
+                    'parts': [
+                      {'text': prompt},
+                    ],
+                  },
+                ],
+              }
             });
           },
           response: {'totalTokens': 2},
@@ -460,7 +465,9 @@ void main() {
               ),
             ),
           ),
-          verifyRequest: (_, request) {
+          verifyRequest: (_, countTokensRequest) {
+            final request = countTokensRequest['generateContentRequest']
+                as Map<String, Object?>;
             expect(request['safetySettings'], [
               {
                 'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -26,7 +26,6 @@ void main() {
       String modelName = defaultModelName,
       RequestOptions? requestOptions,
       Content? systemInstruction,
-      GenerationConfig? generationConfig,
       List<Tool>? tools,
       ToolConfig? toolConfig,
     }) {
@@ -36,7 +35,6 @@ void main() {
         client: client.client,
         requestOptions: requestOptions,
         systemInstruction: systemInstruction,
-        generationConfig: generationConfig,
         tools: tools,
         toolConfig: toolConfig,
       );
@@ -445,6 +443,7 @@ void main() {
                 HarmBlockThreshold.high,
               ),
             ],
+            generationConfig: GenerationConfig(stopSequences: ['a']),
             tools: [
               Tool(functionDeclarations: [
                 FunctionDeclaration(
@@ -468,6 +467,9 @@ void main() {
                 'threshold': 'BLOCK_ONLY_HIGH',
               },
             ]);
+            expect(request['generationConfig'], {
+              'stopSequences': ['a'],
+            });
             expect(request['tools'], [
               {
                 'functionDeclarations': [
@@ -488,19 +490,6 @@ void main() {
                 'allowedFunctionNames': ['someFunction'],
               },
             });
-          },
-        );
-      });
-
-      test('excludes generationConfig', () async {
-        final (client, model) = createModel(
-            generationConfig: GenerationConfig(maxOutputTokens: 1000));
-        final prompt = 'Some prompt';
-        await client.checkRequest(
-          response: {'totalTokens': 100},
-          () => model.countTokens([Content.text(prompt)]),
-          verifyRequest: (_, request) {
-            expect(request, isNot(contains('generationConfig')));
           },
         );
       });

--- a/samples/dart/bin/simple_text.dart
+++ b/samples/dart/bin/simple_text.dart
@@ -22,7 +22,13 @@ void main() async {
     stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
-  final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+  final model = GenerativeModel(
+      model: 'gemini-pro',
+      apiKey: apiKey,
+      safetySettings: [
+        SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
+      ],
+      generationConfig: GenerationConfig(maxOutputTokens: 200));
   final prompt = 'Write a story about a magic backpack.';
   print('Prompt: $prompt');
   final content = [Content.text(prompt)];


### PR DESCRIPTION
This will make the counted tokens aligned with what the model will count
if the same request were made to `generateContent`.

Extract the JSON conversion to a separate method and call it from
`generateContent`, `generateContentStream`, and `countTokens`.
