### PR TITLE
Use updated gemini model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flutter pub add google_generative_ai
 ### Initializing the API client
 
 ```dart
-final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+final model = GenerativeModel(model: 'gemini-1.5-flash-latest', apiKey: apiKey);
 ```
 
 ### Calling the API

--- a/pkgs/google_generative_ai/README.md
+++ b/pkgs/google_generative_ai/README.md
@@ -54,7 +54,10 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 const apiKey = ...;
 
 void main() async {
-  final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+  final model = GenerativeModel(
+      model: 'gemini-1.5-flash-latest',
+      apiKey: apiKey,
+  );
 
   final prompt = 'Write a story about a magic backpack.';
   final content = [Content.text(prompt)];

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -24,7 +24,10 @@
 /// const apiKey = ...;
 ///
 /// void main() async {
-///   final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+///   final model = GenerativeModel(
+///       model: 'gemini-1.5-flash-latest',
+///       apiKey: apiKey,
+///   );
 ///
 ///   final prompt = 'Write a story about a magic backpack.';
 ///   final content = [Content.text(prompt)];

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -64,8 +64,9 @@ final class GenerativeModel {
 
   /// Create a [GenerativeModel] backed by the generative model named [model].
   ///
-  /// The [model] argument can be a model name (such as `'gemini-pro'`) or a
-  /// model code (such as `'models/gemini-pro'` or `'tunedModels/my-model'`).
+  /// The [model] argument can be a model name (such as
+  /// `'gemini-1.5-flash-latest'`) or a model code (such as
+  /// `'models/gemini-1.5-flash-latest'` or `'tunedModels/my-model'`).
   /// There is no creation time check for whether the `model` string identifies
   /// a known and supported model. If not, attempts to generate content
   /// will fail.

--- a/samples/dart/bin/advanced_chat.dart
+++ b/samples/dart/bin/advanced_chat.dart
@@ -23,9 +23,10 @@ Future<void> main() async {
     exit(1);
   }
   final model = GenerativeModel(
-      model: 'gemini-pro',
-      apiKey: apiKey,
-      generationConfig: GenerationConfig(maxOutputTokens: 100));
+    model: 'gemini-1.5-flash-latest',
+    apiKey: apiKey,
+    generationConfig: GenerationConfig(maxOutputTokens: 100),
+  );
   final chat = model.startChat(history: [
     Content.text('Hello, I have 2 dogs in my house.'),
     Content.model([TextPart('Great to meet you. What would you like to know?')])

--- a/samples/dart/bin/advanced_text.dart
+++ b/samples/dart/bin/advanced_text.dart
@@ -23,7 +23,7 @@ void main() async {
     exit(1);
   }
   final model = GenerativeModel(
-      model: 'gemini-pro',
+      model: 'gemini-1.5-flash-latest',
       apiKey: apiKey,
       safetySettings: [
         SafetySetting(HarmCategory.sexuallyExplicit, HarmBlockThreshold.none)

--- a/samples/dart/bin/advanced_text_and_image.dart
+++ b/samples/dart/bin/advanced_text_and_image.dart
@@ -25,7 +25,7 @@ void main() async {
     exit(1);
   }
   final model = GenerativeModel(
-      model: 'gemini-pro-vision',
+      model: 'gemini-1.5-flash-latest',
       apiKey: apiKey,
       generationConfig: GenerationConfig(temperature: 0));
   final prompt =

--- a/samples/dart/bin/guessing_game.dart
+++ b/samples/dart/bin/guessing_game.dart
@@ -20,7 +20,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 Future<List<String>> _generateWords(String apiKey, String subject) async {
   final config = GenerationConfig(candidateCount: 1, temperature: 1.0);
   final model = GenerativeModel(
-    model: 'gemini-pro',
+    model: 'gemini-1.5-pro-latest',
     apiKey: apiKey,
     generationConfig: config,
     requestOptions: RequestOptions(apiVersion: 'v1beta'),
@@ -56,7 +56,7 @@ Future<List<(String, String)>> _generateHints(
     String apiKey, List<String> words) async {
   final config = GenerationConfig(candidateCount: 1, temperature: 0.5);
   final model = GenerativeModel(
-    model: 'gemini-pro',
+    model: 'gemini-1.5-pro-latest',
     apiKey: apiKey,
     generationConfig: config,
     requestOptions: RequestOptions(apiVersion: 'v1beta'),

--- a/samples/dart/bin/simple_chat.dart
+++ b/samples/dart/bin/simple_chat.dart
@@ -22,7 +22,8 @@ Future<void> main() async {
     stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
-  final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+  final model =
+      GenerativeModel(model: 'gemini-1.5-flash-latest', apiKey: apiKey);
   final chat = model.startChat();
   final message = 'Hello! How are you?';
   final content = Content.text(message);

--- a/samples/dart/bin/simple_config.dart
+++ b/samples/dart/bin/simple_config.dart
@@ -19,7 +19,9 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 
 Future<void> generate(GenerationConfig? generationConfig, String apiKey) async {
   final model = GenerativeModel(
-      model: 'gemini-pro', apiKey: apiKey, generationConfig: generationConfig);
+      model: 'gemini-1.5-flash-latest',
+      apiKey: apiKey,
+      generationConfig: generationConfig);
   final prompt = 'One, two, three, ';
   print('Prompt: $prompt');
   final content = [Content.text(prompt)];

--- a/samples/dart/bin/simple_text.dart
+++ b/samples/dart/bin/simple_text.dart
@@ -23,7 +23,7 @@ void main() async {
     exit(1);
   }
   final model = GenerativeModel(
-      model: 'gemini-pro',
+      model: 'gemini-1.5-flash-latest',
       apiKey: apiKey,
       safetySettings: [
         SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)

--- a/samples/dart/bin/simple_text_and_image.dart
+++ b/samples/dart/bin/simple_text_and_image.dart
@@ -24,7 +24,10 @@ void main() async {
     stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
-  final model = GenerativeModel(model: 'gemini-pro-vision', apiKey: apiKey);
+  final model = GenerativeModel(
+    model: 'gemini-1.5-flash-latest',
+    apiKey: apiKey,
+  );
   final prompt = 'What do you see?';
   print('Prompt: $prompt');
 

--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -81,7 +81,6 @@ class ChatWidget extends StatefulWidget {
 
 class _ChatWidgetState extends State<ChatWidget> {
   late final GenerativeModel _model;
-  late final GenerativeModel _visionModel;
   late final ChatSession _chat;
   final ScrollController _scrollController = ScrollController();
   final TextEditingController _textController = TextEditingController();
@@ -94,12 +93,8 @@ class _ChatWidgetState extends State<ChatWidget> {
   void initState() {
     super.initState();
     _model = GenerativeModel(
-      model: 'gemini-pro',
+      model: 'gemini-1.5-flash-latest',
       apiKey: widget.apiKey,
-    );
-    _visionModel = GenerativeModel(
-      model: 'gemini-pro-vision',
-      apiKey: _apiKey,
     );
     _chat = _model.startChat();
   }
@@ -244,7 +239,7 @@ class _ChatWidgetState extends State<ChatWidget> {
         fromUser: true
       ));
 
-      var response = await _visionModel.generateContent(content);
+      var response = await _model.generateContent(content);
       var text = response.text;
       _generatedContent.add((image: null, text: text, fromUser: false));
 


### PR DESCRIPTION
Gemini documentation is standardizing on using versioned model names.
Use `gemini-1.5-flash-latest` for most use cases. Since this model is
multimodal it can replace both `1.0-pro` and `1.0-pro-vision` usage.
Combine the models in the flutter app to one.

Use `gemini-1.5.-pro-latest` for the example with force function calling
(`FunctionCallingMode.any`) since that is unsupported in the flash
model.

Also use the pro model for the other function calling sample. The flash
model should support this in theory, but when I run it in practice it
fails to call the functions.
