### PR TITLE
Add a request escape hatch for the vertex SDK

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+- Internal changes to enable reuse in the Vertex SDK. No user visible changes.
+
 ## 0.4.2
 
 - Add support for `GenerationConfig.responseSchema` for constraining JSON mime

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.2';
+const packageVersion = '0.4.3';

--- a/pkgs/google_generative_ai/lib/src/vertex_hooks.dart
+++ b/pkgs/google_generative_ai/lib/src/vertex_hooks.dart
@@ -25,4 +25,4 @@ export 'api.dart'
         parseCountTokensResponse,
         parseEmbedContentResponse,
         parseGenerateContentResponse;
-export 'model.dart' show createModelWithBaseUri;
+export 'model.dart' show Task, VertexExtensions, createModelWithBaseUri;

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.2
+version: 0.4.3
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
Maintains the internal details of using the client, but offers a general
escape hatch for any unary request by exposing `Task`.

Add a `makeRequest` utility method in an extension, and update the
existing unary requests to use it.
