### PR TITLE
Rewrite function calling sample to standard prompt

### DIFF
--- a/samples/dart/bin/function_calling.dart
+++ b/samples/dart/bin/function_calling.dart
@@ -16,35 +16,51 @@ import 'dart:io';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
 
-void main() async {
+final apiKey = () {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
     stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
+  return apiKey;
+}();
+
+Future<void> functionCalling() async {
+  // [START function_calling]
+  Map<String, Object?> setLightValues(Map<String, Object?> args) {
+    return args;
+  }
+
+  final controlLightFunction = FunctionDeclaration(
+      'controlLight',
+      'Set the brightness and color temperature of a room light.',
+      Schema.object(properties: {
+        'brightness': Schema.number(
+            description:
+                'Light level from 0 to 100. Zero is off and 100 is full brightness.',
+            nullable: false),
+        'colorTemperatur': Schema.string(
+            description:
+                'Color temperature of the light fixture which can be `daylight`, `cool`, or `warm`',
+            nullable: false),
+      }));
+
+  final functions = {controlLightFunction.name: setLightValues};
+  FunctionResponse dispatchFunctionCall(FunctionCall call) {
+    final function = functions[call.name]!;
+    final result = function(call.args);
+    return FunctionResponse(call.name, result);
+  }
+
   final model = GenerativeModel(
     model: 'gemini-1.5-pro-latest',
     apiKey: apiKey,
     tools: [
-      Tool(functionDeclarations: [
-        FunctionDeclaration(
-            'fetchCurrentWeather',
-            'Returns the weather in a given location.',
-            Schema(SchemaType.object, properties: {
-              'location':
-                  Schema.string(description: 'A location name, like "London".'),
-            }, requiredProperties: [
-              'location'
-            ]))
-      ])
+      Tool(functionDeclarations: [controlLightFunction])
     ],
   );
 
-  final prompt =
-      "I'm trying to decide whether to go to London or Zurich this weekend. "
-      'How hot are those cities? How about Singapore? Or maybe Tokyo. '
-      'I want to go somewhere not that cold but not too hot either. '
-      'Suggest a destination.';
+  final prompt = 'Dim the lights so the room feels cozy and warm.';
   final content = [Content.text(prompt)];
   var response = await model.generateContent(content);
 
@@ -52,7 +68,7 @@ void main() async {
   while ((functionCalls = response.functionCalls.toList()).isNotEmpty) {
     var responses = <FunctionResponse>[
       for (final functionCall in functionCalls)
-        _dispatchFunctionCall(functionCall)
+        dispatchFunctionCall(functionCall)
     ];
     content
       ..add(response.candidates.first.content)
@@ -60,40 +76,9 @@ void main() async {
     response = await model.generateContent(content);
   }
   print('Response: ${response.text}');
+  // [END function_calling]
 }
 
-FunctionResponse _dispatchFunctionCall(FunctionCall call) {
-  final result = switch (call.name) {
-    'fetchCurrentWeather' => {
-        'weather': _fetchWeather(WeatherRequest._parse(call.args))
-      },
-    _ => throw UnimplementedError('Function not implemented: ${call.name}')
-  };
-  return FunctionResponse(call.name, result);
-}
-
-class WeatherRequest {
-  static WeatherRequest _parse(Map<String, Object?> jsonObject) =>
-      switch (jsonObject) {
-        {'location': final String location} => WeatherRequest(location),
-        _ =>
-          throw FormatException('Unhandled WeatherRequest format', jsonObject),
-      };
-  final String location;
-  WeatherRequest(this.location);
-
-  @override
-  String toString() => {'location': location}.toString();
-}
-
-var _responseIndex = -1;
-Map<String, Object?> _fetchWeather(WeatherRequest request) {
-  const responses = <Map<String, Object?>>[
-    {'condition': 'sunny', 'temp_c': -23.9},
-    {'condition': 'extreme rainstorm', 'temp_c': 13.9},
-    {'condition': 'cloudy', 'temp_c': 33.9},
-    {'condition': 'moderate', 'temp_c': 19.9},
-  ];
-  _responseIndex = (_responseIndex + 1) % responses.length;
-  return responses[_responseIndex];
+void main() async {
+  await functionCalling();
 }

--- a/samples/dart/bin/function_calling.dart
+++ b/samples/dart/bin/function_calling.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 final apiKey = () {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   return apiKey;
@@ -53,7 +53,7 @@ Future<void> functionCalling() async {
   }
 
   final model = GenerativeModel(
-    model: 'gemini-1.5-pro-latest',
+    model: 'gemini-1.5-pro',
     apiKey: apiKey,
     tools: [
       Tool(functionDeclarations: [controlLightFunction])


### PR DESCRIPTION
Align the prompt and function definition used in the function calling
sample with the cross-language canonical sample.
Move the dispatch helper function from the top level to a local function
to keep the full details within the sample region.
