### PR TITLE
fix(generative-ai-dart) & fix(firebase_vertexai): null role on ChatSession history

### DIFF
--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -27,9 +27,11 @@ import 'utils/mutex.dart';
 /// response.
 final class ChatSession {
   final Future<GenerateContentResponse> Function(Iterable<Content> content,
-      {List<SafetySetting>? safetySettings, GenerationConfig? generationConfig}) _generateContent;
+      {List<SafetySetting>? safetySettings,
+      GenerationConfig? generationConfig}) _generateContent;
   final Stream<GenerateContentResponse> Function(Iterable<Content> content,
-      {List<SafetySetting>? safetySettings, GenerationConfig? generationConfig}) _generateContentStream;
+      {List<SafetySetting>? safetySettings,
+      GenerationConfig? generationConfig}) _generateContentStream;
 
   final _mutex = Mutex();
 
@@ -37,8 +39,8 @@ final class ChatSession {
   final List<SafetySetting>? _safetySettings;
   final GenerationConfig? _generationConfig;
 
-  ChatSession._(
-      this._generateContent, this._generateContentStream, this._history, this._safetySettings, this._generationConfig);
+  ChatSession._(this._generateContent, this._generateContentStream,
+      this._history, this._safetySettings, this._generationConfig);
 
   /// The content that has been successfully sent to, or received from, the
   /// generative model.
@@ -100,7 +102,8 @@ final class ChatSession {
     _mutex.acquire().then((lock) async {
       try {
         final responses = _generateContentStream(_history.followedBy([message]),
-            safetySettings: _safetySettings, generationConfig: _generationConfig);
+            safetySettings: _safetySettings,
+            generationConfig: _generationConfig);
         final content = <Content>[];
         await for (final response in responses) {
           if (response.candidates case [final candidate, ...]) {
@@ -174,6 +177,9 @@ extension StartChatExtension on GenerativeModel {
   /// print(response.text);
   /// ```
   ChatSession startChat(
-          {List<Content>? history, List<SafetySetting>? safetySettings, GenerationConfig? generationConfig}) =>
-      ChatSession._(generateContent, generateContentStream, history ?? [], safetySettings, generationConfig);
+          {List<Content>? history,
+          List<SafetySetting>? safetySettings,
+          GenerationConfig? generationConfig}) =>
+      ChatSession._(generateContent, generateContentStream, history ?? [],
+          safetySettings, generationConfig);
 }


### PR DESCRIPTION
Fixes and closes issue #197

I extended the existing condition to take into account blocked Content with `null` role and avoid adding it to the history.

There is a preexisting "TODO" asking if the role should be appended before adding the content to the history. I did not changed or remove the comment, although in my tests a could not reproduce a case where the role was not `user` or `model` unless the responses had been blocked for Safety or other reasons.

When blocked the `text` part is empty and would not make sense to add it to the history. So no sure the appending the role is needed.

With the check the model keeps working fine and the developer can handle the Exception as it pleases, either retrying the generation or adding a default answer by the `model` so the user can rephrase and retry.

Happy to give more information or make any changes. Hope it helps, thanks for the great work.