### PR TITLE
Allow Vertex formatted CitationMetadata

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+- Allow the Vertex format for citation metadata - read either `citationSources`
+  or `citations` keys, whichever exists. Fixes a `FormatException` when parsing
+  vertex results with citations.
+
 ## 0.4.3
 
 - Internal changes to enable reuse in the Vertex SDK. No user visible changes.

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -736,6 +736,8 @@ CitationMetadata _parseCitationMetadata(Object? jsonObject) {
   return switch (jsonObject) {
     {'citationSources': final List<Object?> citationSources} =>
       CitationMetadata(citationSources.map(_parseCitationSource).toList()),
+    {'citations': final List<Object?> citationSources} =>
+      CitationMetadata(citationSources.map(_parseCitationSource).toList()),
     _ => throw FormatException('Unhandled CitationMetadata format', jsonObject),
   };
 }

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -736,6 +736,7 @@ CitationMetadata _parseCitationMetadata(Object? jsonObject) {
   return switch (jsonObject) {
     {'citationSources': final List<Object?> citationSources} =>
       CitationMetadata(citationSources.map(_parseCitationSource).toList()),
+    // Vertex SDK format uses `citations`
     {'citations': final List<Object?> citationSources} =>
       CitationMetadata(citationSources.map(_parseCitationSource).toList()),
     _ => throw FormatException('Unhandled CitationMetadata format', jsonObject),

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.3';
+const packageVersion = '0.4.4';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.3
+version: 0.4.4
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -370,6 +370,140 @@ void main() {
       );
     });
 
+    test('with a vertex formatted citation', () async {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "placeholder"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        }
+      ],
+      "citationMetadata": {
+        "citations": [
+          {
+            "startIndex": 574,
+            "endIndex": 705,
+            "uri": "https://example.com/",
+            "license": ""
+          },
+          {
+            "startIndex": 899,
+            "endIndex": 1026,
+            "uri": "https://example.com/",
+            "license": ""
+          },
+          {
+            "startIndex": 899,
+            "endIndex": 1026
+          },
+          {
+            "uri": "https://example.com/",
+            "license": ""
+          },
+          {}
+        ]
+      }
+    }
+  ],
+  "promptFeedback": {
+    "safetyRatings": [
+      {
+        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HATE_SPEECH",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "probability": "NEGLIGIBLE"
+      }
+    ]
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+        generateContentResponse,
+        matchesGenerateContentResponse(
+          GenerateContentResponse(
+            [
+              Candidate(
+                Content.model([TextPart('placeholder')]),
+                [
+                  SafetyRating(
+                    HarmCategory.sexuallyExplicit,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.hateSpeech,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.harassment,
+                    HarmProbability.negligible,
+                  ),
+                  SafetyRating(
+                    HarmCategory.dangerousContent,
+                    HarmProbability.negligible,
+                  ),
+                ],
+                CitationMetadata([
+                  CitationSource(574, 705, Uri.https('example.com', ''), ''),
+                  CitationSource(899, 1026, Uri.https('example.com', ''), ''),
+                ]),
+                FinishReason.stop,
+                null,
+              ),
+            ],
+            PromptFeedback(null, null, [
+              SafetyRating(
+                HarmCategory.sexuallyExplicit,
+                HarmProbability.negligible,
+              ),
+              SafetyRating(HarmCategory.hateSpeech, HarmProbability.negligible),
+              SafetyRating(HarmCategory.harassment, HarmProbability.negligible),
+              SafetyRating(
+                HarmCategory.dangerousContent,
+                HarmProbability.negligible,
+              ),
+            ]),
+          ),
+        ),
+      );
+    });
+
     test('allows missing content', () async {
       final response = '''
 {


### PR DESCRIPTION
Fixes #184

The vertex backend uses a similar data model, but names the field
`citations` instead of `citationSources`. Read either field, whichever
exists, and parse it otherwise consistently.
