### PR TITLE
Rename GOOGLE_API_KEY as GEMINI_API_KEY

### DIFF
--- a/samples/dart/README.md
+++ b/samples/dart/README.md
@@ -6,7 +6,7 @@ To try these samples out, follow these steps:
 
 - To use the Gemini API, you'll need an API key. If you don't already have one, 
   create a key in Google AI Studio: https://aistudio.google.com/app/apikey.
-- Export a `$GOOGLE_API_KEY` environment variable with an API key with access to
+- Export a `$GEMINI_API_KEY` environment variable with an API key with access to
   the Gemini generative models, or run the below commands with an environment
   containing this variable.
 - Run any sample from the `bin` directory (e.g., `dart bin/simple_text.dart`).

--- a/samples/dart/bin/advanced_chat.dart
+++ b/samples/dart/bin/advanced_chat.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 Future<void> main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/advanced_text.dart
+++ b/samples/dart/bin/advanced_text.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 void main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/advanced_text_and_image.dart
+++ b/samples/dart/bin/advanced_text_and_image.dart
@@ -19,9 +19,9 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 import 'util/resource.dart';
 
 void main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/guessing_game.dart
+++ b/samples/dart/bin/guessing_game.dart
@@ -101,9 +101,9 @@ bool guessWord(String word, String hint) {
 }
 
 Future<void> main(List<String> args) async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
 

--- a/samples/dart/bin/safety_settings.dart
+++ b/samples/dart/bin/safety_settings.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 final apiKey = () {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   return apiKey;

--- a/samples/dart/bin/simple_chat.dart
+++ b/samples/dart/bin/simple_chat.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 Future<void> main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model =

--- a/samples/dart/bin/simple_config.dart
+++ b/samples/dart/bin/simple_config.dart
@@ -34,9 +34,9 @@ Future<void> generate(GenerationConfig? generationConfig, String apiKey) async {
 }
 
 Future<void> main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   await generate(null, apiKey);

--- a/samples/dart/bin/simple_embedding.dart
+++ b/samples/dart/bin/simple_embedding.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 void main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(model: 'embedding-001', apiKey: apiKey);

--- a/samples/dart/bin/simple_text.dart
+++ b/samples/dart/bin/simple_text.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 void main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/simple_text_and_image.dart
+++ b/samples/dart/bin/simple_text_and_image.dart
@@ -19,9 +19,9 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 import 'util/resource.dart';
 
 void main() async {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/system_instructions.dart
+++ b/samples/dart/bin/system_instructions.dart
@@ -17,9 +17,9 @@ import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
 
 final apiKey = () {
-  final apiKey = Platform.environment['GOOGLE_API_KEY'];
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
   if (apiKey == null) {
-    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
     exit(1);
   }
   return apiKey;

--- a/samples/flutter_app/README.md
+++ b/samples/flutter_app/README.md
@@ -12,7 +12,7 @@ create a key in Google AI Studio: https://aistudio.google.com/app/apikey.
 When running the app, include your API key using the `--dart-define` flag:
 
 ```bash
-flutter run --dart-define=API_KEY=$GOOGLE_API_KEY
+flutter run --dart-define=API_KEY=$GEMINI_API_KEY
 ```
 
 If you use VSCode, you can [specify `--dart-define`


### PR DESCRIPTION
The standardized samples are already using `GEMINI_API_KEY`.
https://github.com/google-gemini/generative-ai-dart/pull/188#discussion_r1676329979

Update the non-standard samples to use the same.
