### PR TITLE
Add support for code execution

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.5
+
+- Add support for model side Code Execution. Enable code execution by
+  configuring `Tools` with a `codeExecution` argument.
+
 ## 0.4.4
 
 - Allow the Vertex format for citation metadata - read either `citationSources`

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -65,11 +65,15 @@ export 'src/api.dart'
 export 'src/chat.dart' show ChatSession, StartChatExtension;
 export 'src/content.dart'
     show
+        CodeExecutionResult,
         Content,
         DataPart,
+        ExecutableCode,
         FilePart,
         FunctionCall,
         FunctionResponse,
+        Language,
+        Outcome,
         Part,
         TextPart;
 export 'src/error.dart'
@@ -80,6 +84,7 @@ export 'src/error.dart'
         UnsupportedUserLocation;
 export 'src/function_calling.dart'
     show
+        CodeExecution,
         FunctionCallingConfig,
         FunctionCallingMode,
         FunctionDeclaration,

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -77,6 +77,20 @@ Part _parsePart(Object? jsonObject) {
       throw UnimplementedError('FunctionResponse part not yet supported'),
     {'inlineData': {'mimeType': String _, 'data': String _}} =>
       throw UnimplementedError('inlineData content part not yet supported'),
+    {
+      'executableCode': {
+        'language': final String language,
+        'code': final String code,
+      }
+    } =>
+      ExecutableCode(Language._parse(language), code),
+    {
+      'codeExecutionResult': {
+        'outcome': final String outcome,
+        'output': final String output,
+      }
+    } =>
+      CodeExecutionResult(Outcome._parse(outcome), output),
     _ => throw FormatException('Unhandled Part format', jsonObject),
   };
 }
@@ -150,5 +164,83 @@ final class FunctionResponse implements Part {
   @override
   Object toJson() => {
         'functionResponse': {'name': name, 'response': response}
+      };
+}
+
+/// The code that was executed by the model to generate a response.
+///
+/// When code execution is enabled, the model may generate code and run it
+/// during the course of generating the text response. When it does, the code
+/// is included as an `ExecutableCode` in the content.
+final class ExecutableCode implements Part {
+  final Language language;
+  final String code;
+
+  ExecutableCode(this.language, this.code);
+  @override
+  Object toJson() => {
+        'executable_code': {
+          'langage': language.toJson(),
+          'code': code,
+        }
+      };
+}
+
+/// The output from running an [ExecutableCode] to generate a response.
+///
+/// When code execution is enabled, the model may generate code and run it
+/// during the course of generating the text response. When it does, the output
+/// from the code is included as a `CodeExecutionResult` in the content.
+final class CodeExecutionResult implements Part {
+  final Outcome outcome;
+  final String output;
+  CodeExecutionResult(this.outcome, this.output);
+
+  @override
+  Object toJson() => {
+        'code_execution_result': {
+          'outcome': outcome.toJson(),
+          'output': output,
+        }
+      };
+}
+
+/// A programming language used in an [ExecutableCode].
+enum Language {
+  unspecified,
+  python;
+
+  static Language _parse(Object jsonObject) => switch (jsonObject) {
+        'LANGUAGE_UNSPECIFIED' => unspecified,
+        'PYTHON' => python,
+        _ => throw FormatException('Unhandled Language format', jsonObject),
+      };
+
+  String toJson() => switch (this) {
+        unspecified => 'LANGUAGE_UNSPECIFIED',
+        python => 'PYTHON',
+      };
+}
+
+/// The type of result from running an [ExecutableCode].
+enum Outcome {
+  unspecified,
+  ok,
+  failed,
+  deadlineExceeded;
+
+  static Outcome _parse(Object jsonObject) => switch (jsonObject) {
+        'OUTCOME_UNSPECIFIED' => unspecified,
+        'OUTCOME_OK' => ok,
+        'OUTCOME_FAILED' => failed,
+        'OUTCOME_DEADLINE_EXCEEDED' => deadlineExceeded,
+        _ => throw FormatException('Unhandled Language format', jsonObject),
+      };
+
+  String toJson() => switch (this) {
+        unspecified => 'OUTCOME_UNSPECIFIED',
+        ok => 'OUTCOME_OK',
+        failed => 'OUTCOME_FAILED',
+        deadlineExceeded => 'OUTCOME_DEADLINE_EXCEEDED',
       };
 }

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -30,12 +30,15 @@ final class Tool {
   /// with the role "function" generation context for the next model turn.
   final List<FunctionDeclaration>? functionDeclarations;
 
-  Tool({this.functionDeclarations});
+  final CodeExecution? codeExecution;
+
+  Tool({this.functionDeclarations, this.codeExecution});
 
   Map<String, Object> toJson() => {
         if (functionDeclarations case final functionDeclarations?)
           'functionDeclarations':
               functionDeclarations.map((f) => f.toJson()).toList(),
+        if (codeExecution != null) 'codeExecution': <String, Object?>{},
       };
 }
 
@@ -65,6 +68,14 @@ final class FunctionDeclaration {
         if (parameters case final parameters?) 'parameters': parameters.toJson()
       };
 }
+
+/// An empty configuration marker to enable code execution.
+///
+/// When code execution is enabled the model may generate code and run it in the
+/// process of generating a response to the prompt. When this happens the code
+/// that was executed and it's output will be included in the response as
+/// [ExecutableCode] and [CodeExecutionResult] parts.
+class CodeExecution {}
 
 final class ToolConfig {
   final FunctionCallingConfig? functionCallingConfig;

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.4';
+const packageVersion = '0.4.5';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.4
+version: 0.4.5
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -294,6 +294,36 @@ void main() {
           response: arbitraryGenerateContentResponse,
         );
       });
+
+      test('can enable code execution', () async {
+        final (client, model) =
+            createModel(tools: [Tool(codeExecution: CodeExecution())]);
+        final prompt = 'Some prompt';
+        await client.checkRequest(
+          () => model.generateContent([Content.text(prompt)]),
+          verifyRequest: (_, request) {
+            expect(request['tools'], [
+              {'codeExecution': <String, Object?>{}}
+            ]);
+          },
+          response: arbitraryGenerateContentResponse,
+        );
+      });
+
+      test('can override code execution', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        await client.checkRequest(
+          () => model.generateContent([Content.text(prompt)],
+              tools: [Tool(codeExecution: CodeExecution())]),
+          verifyRequest: (_, request) {
+            expect(request['tools'], [
+              {'codeExecution': <String, Object?>{}}
+            ]);
+          },
+          response: arbitraryGenerateContentResponse,
+        );
+      });
     });
 
     group('generate content stream', () {

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -504,6 +504,62 @@ void main() {
       );
     });
 
+    test('with code execution', () async {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "executableCode": {
+              "language": "PYTHON",
+              "code": "print('hello world')"
+            }
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_OK",
+              "output": "hello world"
+            }
+          },
+          {
+            "text": "hello world"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+        generateContentResponse,
+        matchesGenerateContentResponse(
+          GenerateContentResponse(
+            [
+              Candidate(
+                Content.model([
+                  ExecutableCode(Language.python, 'print(\'hello world\')'),
+                  CodeExecutionResult(Outcome.ok, 'hello world'),
+                  TextPart('hello world')
+                ]),
+                [],
+                null,
+                FinishReason.stop,
+                null,
+              ),
+            ],
+            null,
+          ),
+        ),
+      );
+    });
+
     test('allows missing content', () async {
       final response = '''
 {

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -41,6 +41,14 @@ Matcher matchesPart(Part part) => switch (part) {
             // TODO: When updating min SDK remove ignore.
             // ignore: unused_result, implementation bug
             .having((p) => p.response, 'args', response),
+      ExecutableCode(language: final language, code: final code) =>
+        isA<ExecutableCode>()
+            .having((p) => p.language, 'language', language)
+            .having((p) => p.code, 'code', code),
+      CodeExecutionResult(outcome: final outcome, output: final output) =>
+        isA<CodeExecutionResult>()
+            .having((p) => p.outcome, 'outcome', outcome)
+            .having((p) => p.output, 'output', output),
       _ => throw StateError('Unhandled Part type.'),
     };
 

--- a/samples/dart/bin/code_execution.dart
+++ b/samples/dart/bin/code_execution.dart
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:google_generative_ai/google_generative_ai.dart';
+
+// Set up your API Key
+//
+// To use the Gemini API, you'll need an API key.
+// To learn more, see the "Set up your API Key" section in the Gemini API
+// quickstart:
+// https://ai.google.dev/gemini-api/docs/quickstart?lang=swift#set-up-api-key
+final apiKey = () {
+  final apiKey = Platform.environment['GEMINI_API_KEY'];
+  if (apiKey == null) {
+    stderr.writeln(r'No $GEMINI_API_KEY environment variable');
+    exit(1);
+  }
+  return apiKey;
+}();
+
+Future<void> codeExecutionBasic() async {
+  // [START code_execution_basic]
+  final model = GenerativeModel(
+    // Specify a Gemini model appropriate for your use case
+    model: 'gemini-1.5-flash',
+    apiKey: apiKey,
+    tools: [Tool(codeExecution: CodeExecution())],
+  );
+  final prompt = 'What is the sum of the first 50 prime numbers? '
+      'Generate and run code for the calculation, and make sure you get '
+      'all 50.';
+
+  final response = await model.generateContent([Content.text(prompt)]);
+  print(response.text);
+  // [END code_execution_basic]
+}
+
+Future<void> codeExecutionChat() async {
+  // [START code_execution_chat]
+  final model = GenerativeModel(
+    // Specify a Gemini model appropriate for your use case
+    model: 'gemini-1.5-flash',
+    apiKey: apiKey,
+    tools: [Tool(codeExecution: CodeExecution())],
+  );
+  final chat = model.startChat();
+  final prompt = 'What is the sum of the first 50 prime numbers? '
+      'Generate and run code for the calculation, and make sure you get '
+      'all 50.';
+
+  final response = await chat.sendMessage(Content.text(prompt));
+  print(response.text);
+  // [END code_execution_chat]
+}
+
+void main() async {
+  codeExecutionBasic();
+  codeExecutionChat();
+}


### PR DESCRIPTION
Add `CodeExecutionResult` and `ExecutableCode` which are new `Part`
subtypes that the model may reply with when code execution is enabled.
Add `CodeExecution` configuration class as a marker to enable code
execution. In the future additional configuration parameters may be
added

Add the standardized samples for code execution through the model and a
chat.

Add tests for forwarding configuration and parsing.

Bump version and prepare to publish.
