### PR TITLE
Default the role to 'model' for chat responses

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for model side Code Execution. Enable code execution by
   configuring `Tools` with a `codeExecution` argument.
+- Use a default role `'model'` when a chat response comes back with no role.
 
 ## 0.4.4
 

--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -70,8 +70,10 @@ final class ChatSession {
           safetySettings: _safetySettings, generationConfig: _generationConfig);
       if (response.candidates case [final candidate, ...]) {
         _history.add(message);
-        // TODO: Append role?
-        _history.add(candidate.content);
+        final normalizedContent = candidate.content.role == null
+            ? Content('model', candidate.content.parts)
+            : candidate.content;
+        _history.add(normalizedContent);
       }
       return response;
     } finally {


### PR DESCRIPTION
Fixes #197

A content requires a role when it is sent to the model in the history.
If the backend happens to respond with a message that has no role,
default it to 'model'.
