### PR TITLE
Server error handling when generating content

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+- Throw a more relevant exception for server error HTTP responses.
+
 ## 0.4.5
 
 - Add support for model side Code Execution. Enable code execution by

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -64,7 +64,7 @@ final class HttpApiClient implements ApiClient {
     );
     if (response.statusCode >= 500) {
       throw GenerativeAIException(
-          'Server Error, Status Code: ${response.statusCode}');
+          'Server Error [${response.statusCode}]: ${response.body}');
     }
 
     return _utf8Json.decode(response.bodyBytes) as Map<String, Object?>;

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../google_generative_ai.dart';
 import 'version.dart';
 
 const clientName = 'genai-dart/$packageVersion';
@@ -61,6 +62,11 @@ final class HttpApiClient implements ApiClient {
       headers: await _headers(),
       body: _utf8Json.encode(body),
     );
+    if (response.statusCode >= 500) {
+      throw GenerativeAIException(
+          'Server Error, Status Code: ${response.statusCode}');
+    }
+
     return _utf8Json.decode(response.bodyBytes) as Map<String, Object?>;
   }
 

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -17,7 +17,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-import '../google_generative_ai.dart';
+import 'error.dart';
 import 'version.dart';
 
 const clientName = 'genai-dart/$packageVersion';

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.5';
+const packageVersion = '0.4.6';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.5
+version: 0.4.6
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
This is a simple throw give a clear message about the error when the server is not able to generate the content.

Aims to solve the Issue #206.