### PR TITLE
Update the package's readme to indicate the deprecation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # [Deprecated] Google AI Dart SDK for the Gemini API
 
-With Gemini 2.0, we took the chance to create a unified SDK for mobile developers who want to use Google's GenAI models (Gemini, Veo, Imagen, etc). As part of that process, we took all of the feedback from this SDK and what developers like about other SDKs in the ecosystem to direclty work with the [Firebase SDK](https://firebase.google.com/docs/vertex-ai). We don't plan to add anything to this SDK or making any further changes. We know how disruptive an SDK change can be and don't take this change lightly, but our goal is to create an extremely simple and clear path for developers to build with our models so it felt necessary to make this change.
+With Gemini 2.0, we took the chance to create a unified SDK for mobile
+developers who want to use Google's GenAI models (Gemini, Veo, Imagen, etc). As
+part of that process, we took all of the feedback from this SDK and what
+developers like about other SDKs in the ecosystem to directly work with the
+[Firebase SDK](https://firebase.google.com/docs/vertex-ai). We don't plan to add
+anything to this SDK or make any further changes. We know how disruptive an SDK
+change can be and don't take this change lightly, but our goal is to create an
+extremely simple and clear path for developers to build with our models so it
+felt necessary to make this change.
 
-Thank you for building with Gemini and [let us know](https://discuss.ai.google.dev/c/gemini-api/4) if you need any help!
+Thank you for building with Gemini and
+[let us know](https://discuss.ai.google.dev/c/gemini-api/4) if you need any
+help!

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.7
+
+- Update the README.md to indicate that this package is deprecated; using the
+  [Firebase SDK](https://firebase.google.com/docs/vertex-ai) is the preferred
+  path forward.
+
 ## 0.4.6
 
 - Throw a more relevant exception for server error HTTP responses.

--- a/pkgs/google_generative_ai/README.md
+++ b/pkgs/google_generative_ai/README.md
@@ -1,83 +1,15 @@
-[![package:google_generative_ai](https://github.com/google/generative-ai-dart/actions/workflows/google_generative_ai.yml/badge.svg)](https://github.com/google/generative-ai-dart/actions/workflows/google_generative_ai.yml)
-[![pub package](https://img.shields.io/pub/v/google_generative_ai.svg)](https://pub.dev/packages/google_generative_ai)
-[![package publisher](https://img.shields.io/pub/publisher/google_generative_ai.svg)](https://pub.dev/packages/google_generative_ai/publisher)
+# [Deprecated] Google AI Dart SDK for the Gemini API
 
-The Google AI Dart SDK enables developers to use Google's state-of-the-art
-generative AI models (like Gemini) to build AI-powered features and
-applications. This SDK supports use cases like:
+With Gemini 2.0, we took the chance to create a unified SDK for mobile
+developers who want to use Google's GenAI models (Gemini, Veo, Imagen, etc). As
+part of that process, we took all of the feedback from this SDK and what
+developers like about other SDKs in the ecosystem to directly work with the
+[Firebase SDK](https://firebase.google.com/docs/vertex-ai). We don't plan to add
+anything to this SDK or make any further changes. We know how disruptive an SDK
+change can be and don't take this change lightly, but our goal is to create an
+extremely simple and clear path for developers to build with our models so it
+felt necessary to make this change.
 
--   Generate text from text-only input
--   Generate text from text-and-images input (multimodal)
--   Build multi-turn conversations (chat)
--   Embedding
-
-> [!CAUTION]
-> **Using the Google AI SDK for Dart (Flutter) to call the Google AI Gemini API
-> directly from your app is recommended for prototyping only.** If you plan to
-> enable billing, we strongly recommend that you use the SDK to call the Google
-> AI Gemini API only server-side to keep your API key safe. You risk potentially
-> exposing your API key to malicious actors if you embed your API key directly
-> in your mobile or web app or fetch it remotely at runtime.
-
-## Getting started
-
-### Get an API key
-
-Using the Google AI Dart SDK requires an API key; see
-https://ai.google.dev/tutorials/setup for how to create one.
-
-### Add the package to your project
-
-Add a dependency on the `package:google_generative_ai` package like so:
-
-```shell
-dart pub add google_generative_ai
-```
-
-or:
-
-```shell
-flutter pub add google_generative_ai
-```
-
-Additionally, import:
-
-```dart
-import 'package:google_generative_ai/google_generative_ai.dart';
-```
-
-### Use the API
-
-```dart
-import 'package:google_generative_ai/google_generative_ai.dart';
-
-const apiKey = ...;
-
-void main() async {
-  final model = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
-      apiKey: apiKey,
-  );
-
-  final prompt = 'Write a story about a magic backpack.';
-  final content = [Content.text(prompt)];
-  final response = await model.generateContent(content);
-
-  print(response.text);
-};
-```
-
-See additional examples at
-[samples/](https://github.com/google/generative-ai-dart/tree/main/samples).
-
-For detailed instructions, you can find a quickstart for the Google AI Dart SDK
-in the Google documentation: http://ai.google.dev/tutorials/dart_quickstart.
-This quickstart describes how to add your API key and the SDK to your app,
-initialize the model, and then call the API to access the model. It also
-describes some additional use cases and features, like streaming, embedding,
-counting tokens, and controlling responses.
-
-## Additional documentation
-
-You can find additional documentation for the Google AI SDKs and the Gemini
-model at [ai.google.dev/docs](https://ai.google.dev/docs).
+Thank you for building with Gemini and
+[let us know](https://discuss.ai.google.dev/c/gemini-api/4) if you need any
+help!

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.4.6';
+const packageVersion = '0.4.7';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.4.6
+version: 0.4.7
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
- update the package's readme to indicate the deprecation status
- rev. the package version in prep. for publishing
- a follow-up to https://github.com/google-gemini/deprecated-generative-ai-dart/pull/228

Hi @logankilpatrick - we'll also need to update the package's readme and publish it one last time in order to update the version at https://pub.dev/packages/google_generative_ai.

